### PR TITLE
Generate and set api key

### DIFF
--- a/api.py
+++ b/api.py
@@ -374,13 +374,21 @@ def remove_orchestration(**kwargs):
 def create_orchestration(orchestration_def, **kwargs):
     return make_post_request(orchestration_def, 'orchestrations/create', **kwargs)
 
+
 def save_as_orchestration(orchestration_id, saveas_orchestration_def, replace, **kwargs):
     if replace:
         saveas_orchestration_def["replace"] = True
     return make_post_request(saveas_orchestration_def, 'orchestrations/save-as/{}'.format(orchestration_id), **kwargs)
 
+
 def save_orchestration(orchestration_id, **kwargs):
     return make_post_request(None, 'orchestrations/save/{}'.format(orchestration_id), **kwargs)
+
+
+def create_api_key(**kwargs):
+    response = make_post_request({"description": "Generated and used by conduce-python-api"}, 'apikeys/create', **kwargs);
+    return json.loads(response.content)['apikey'];
+
 
 def make_post_request(payload, fragment, **kwargs):
     return _make_post_request(payload, compose_uri(fragment), **kwargs)
@@ -403,6 +411,7 @@ def _make_post_request(payload, uri, **kwargs):
             user = cfg['default-user']
         auth = session.get_session(host, user)
 
+    headers = {}
     url = 'https://{}/{}'.format(host, uri)
     if 'Authorization' in auth:
         if 'headers' in kwargs and kwargs['headers']:
@@ -454,6 +463,7 @@ def _file_post_request(payload, uri, **kwargs):
             user = cfg['default-user']
         auth = session.get_session(host, user)
 
+    headers = {}
     url = 'https://{}/{}'.format(host, uri)
     if 'Authorization' in auth:
         if 'headers' in kwargs and kwargs['headers']:

--- a/conduce.py
+++ b/conduce.py
@@ -47,6 +47,15 @@ def remove_dataset(args):
     return api.remove_dataset(**vars(args))
 
 
+def set_api_key(args):
+    if args.new == True:
+        args.key = api.create_api_key(**vars(args))
+    if args.key == None:
+        raise ValueError('An API must either be provided with the --key argument or you must generate a new key with --new')
+    config.set_api_key(args)
+    return "API key set for {} on {}".format(args.user, args.host)
+
+
 def send_get_request(args):
     uri = args.uri
     del vars(args)['uri']
@@ -88,7 +97,8 @@ if __name__ == '__main__':
     parser_config_set_api_key.add_argument('--user', help='The user to which the API key belongs')
     parser_config_set_api_key.add_argument('--host', help='The server on which the API key is valid')
     parser_config_set_api_key.add_argument('--key', help='The API key')
-    parser_config_set_api_key.set_defaults(func=config.set_api_key)
+    parser_config_set_api_key.add_argument('--new', help='Generate a new API key', action='store_true')
+    parser_config_set_api_key.set_defaults(func=set_api_key)
 
     parser_config_get = parser_config_subparsers.add_parser('get', help='Get Conduce configuration setting')
     parser_config_get_subparsers = parser_config_get.add_subparsers(help='get subcommands')
@@ -161,7 +171,7 @@ if __name__ == '__main__':
 
     args = arg_parser.parse_args()
 
-    config = config.get_full_config()
+    user_config = config.get_full_config()
 
     try:
         result = args.func(args)

--- a/config.py
+++ b/config.py
@@ -87,7 +87,7 @@ def get_api_key_config(args):
 
     if get_env_from_host(args.host) in config[args.user]['api-keys']:
         key = config[args.user]['api-keys'][get_env_from_host(args.host)]
-        return "{{ 'user': '{}', 'host': '{}', 'api-key': '{}' }}".format(args.user, args.host, key)
+        return '{{ "user": "{}", "host": "{}", "api-key": "{}" }}'.format(args.user, args.host, key)
 
 
 def get_api_key(user, host):

--- a/session.py
+++ b/session.py
@@ -37,7 +37,7 @@ def get_session(host, email):
 
 
 def validate_session(host, cookies):
-    response = requests.get("https://{}/api/validate-session".format(host), cookies=cookies)
+    response = requests.get("https://{}/conduce/api/v1/user/validate-session".format(host), cookies=cookies)
     if response.status_code == 401:
         print "Session expired"
         cookies = None
@@ -52,7 +52,7 @@ def login(host, email, password):
     if password is None:
         raise Exception('No password provided for login')
 
-    response = requests.post("https://{}/api/login".format(host), json={
+    response = requests.post("https://{}/conduce/api/v1/user/login".format(host), json={
         "email": email,
         "password": password,
         "keep": False,


### PR DESCRIPTION
Added this command:

```
python conduce/conduce.py config set api-key --host=banksy-dev.conduce.com --user=enterprise_test@conduce.com --new
```
User must specify --key or --new.  Otherwise a ValueError will be thrown.