### PR TITLE
Ensure user exists before checking api-key

### DIFF
--- a/config.py
+++ b/config.py
@@ -92,8 +92,9 @@ def get_api_key_config(args):
 
 def get_api_key(user, host):
     config = open_config()
-    if get_env_from_host(host) in config[user]['api-keys']:
-        return config[user]['api-keys'][get_env_from_host(host)]
+    if user in config:
+        if get_env_from_host(host) in config[user]['api-keys']:
+            return config[user]['api-keys'][get_env_from_host(host)]
 
 
 def get_default_user(args):


### PR DESCRIPTION
If a new user tries to use the utility to generate an API key because the email address does not exist in the configuration.  Busch league.  This change validates the key is valid before checking the value.