### PR TITLE
Updated readme for module installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,28 @@ This library implements the most commonly used Conduce API endpoints.  It can be
 
 # Installation
 
-If you want this library available to import for various functions and want command line
-utilities added to the path install this using:
+To install using pip:
 
-    sudo python setup.py install
+```
+pip install git+git://github.com/ConduceInc/conduce-python-api
+```
+
+or clone the repository and run:
+
+```
+python setup.py install
+```
 
 # Conduce Command Line Utilities
 
 ## Getting started
-If you want to use the CLI without any setup you may fully specify your requests on the command line.
 
-The examples below assume this is running from source, and use the `python conduce.py` command.  If this
-library is installed, you can substitute in `conduce-api`.
+If you want to use the CLI without any setup you may fully specify your requests on the command line.
 
 To list all datasets just:
 
 ```
-python conduce.py list datasets --host=dev-app.conduce.com --user=enterprise_test@conduce.com
+conduce-api list datasets --host=dev-app.conduce.com --user=enterprise_test@conduce.com
 ```
 
 Otherwise you'll want to setup a configuration, either by adding `~/.conduceconfig` and entering the configuration data, or by using the `config` subcommand:
@@ -31,20 +36,25 @@ Otherwise you'll want to setup a configuration, either by adding `~/.conduceconf
 To list configuration options and syntax:
 
 ```
-python conduce.py config --help
+conduce-api config --help
 ```
 
 The basics:
 
+Use the following commands to avoid specifying your email address and the target server on the command line:
 ```
-python conduce.py config set default-user valid_user_name
-python conduce.py config set default-host valid_host_name
+conduce-api config set default-user valid_user_name
+conduce-api config set default-host valid_host_name
 ```
 
 If you want to avoid typing your password add API keys for the desired accounts:
 
 ```
-python conduce.py config set api-key --key=valid_api_key --user=valid_user --host=valid_host
+conduce-api config set api-key --key=valid_api_key --user=valid_user --host=valid_host
+```
+or create an API key by adding the `--new` flag
+```
+conduce-api config set api-key --new --user=valid_user --host=valid_host
 ```
 
 If you provide an API key for your default user and host you will never have to enter credentials to use that account as long as the API key is valid.
@@ -72,7 +82,7 @@ dhl-dev@conduce.com:
   api-keys:
     dev-app: 'valid_api_key'
     prd-app: ''
-    stg-app: '' 
+    stg-app: ''
 ```
 
 and is stored at `~/.conduceconfig`


### PR DESCRIPTION
Remove the references to running the command line utility from source
and provide instructions for installing with pip.