### PR TITLE
Accept more literal URIs

### DIFF
--- a/api.py
+++ b/api.py
@@ -80,7 +80,7 @@ def compose_uri(fragment):
     prefix = 'conduce/api/v1'
     fragment = fragment.lstrip('/')
     uri = '{}'.format(fragment)
-    if not prefix in fragment:
+    if not 'conduce/api' in fragment:
         uri = '{}/{}'.format(prefix, fragment)
 
     return uri


### PR DESCRIPTION
If user passes 'conduce/api' in uri fragment don't prepend
'conduce/api/v1'