### PR TITLE
doc create api key

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ If you provide an API key for your default user and host you will never have to 
 
 The CLI provides many high level functions.  These include:
 
+- Creating API keys
 - Adding and removing datasets
 - Creating a dataset from a CSV or JSON file
-- Adding generic data to a dataset entity
-- Listing datasets and orchestrations
+- Listing datasets and other resources
 
 All CLI functionality is available through `conduce/api.py` and all API functionality should be usable with or without a `.conduceconfig` file.
 

--- a/api.py
+++ b/api.py
@@ -693,7 +693,53 @@ def create_orchestration(name, orchestration_def, **kwargs):
     return create_json_resource('ORCHESTRATION', name, orchestration_def, **kwargs)
 
 
+def list_api_keys(**kwargs):
+    """
+    Get the users's API keys. 
+
+    Send an HTTP GET request to list this user's API keys.
+
+    Parameters
+    ----------
+    **kwargs
+        See :py:func:`make_get_request`
+
+    Returns
+    -------
+    requests.Response
+        Returns a list of API key dictionaries.
+
+    Raises
+    ------
+    requests.HTTPError
+        Requests that result in an error raise an exception with information about the failure. See :py:func:`requests.Response.raise_for_status` for more information.
+    """
+
+    response = make_get_request('apikeys/list', **kwargs)
+    return json.loads(response.content)
+
+
 def create_api_key(**kwargs):
+    """
+    Add an API key to a user's account.
+
+    Send an HTTP POST request for a new API key.  The API key is added to the account of the user who made the request.
+
+    Parameters
+    ----------
+    **kwargs
+        See :py:func:`make_post_request`
+
+    Returns
+    -------
+    requests.Response
+        Returns the string representation of the new API key.
+
+    Raises
+    ------
+    requests.HTTPError
+        Requests that result in an error raise an exception with information about the failure. See :py:func:`requests.Response.raise_for_status` for more information.
+    """
     response = make_post_request(
         {"description": "Generated and used by conduce-python-api"}, 'apikeys/create', **kwargs)
     return json.loads(response.content)['apikey']

--- a/api.py
+++ b/api.py
@@ -695,7 +695,7 @@ def create_orchestration(name, orchestration_def, **kwargs):
 
 def list_api_keys(**kwargs):
     """
-    Get the users's API keys. 
+    Get this users's API keys.
 
     Send an HTTP GET request to list this user's API keys.
 
@@ -721,7 +721,7 @@ def list_api_keys(**kwargs):
 
 def create_api_key(**kwargs):
     """
-    Add an API key to a user's account.
+    Add an API key to this user's account.
 
     Send an HTTP POST request for a new API key.  The API key is added to the account of the user who made the request.
 

--- a/conduce.py
+++ b/conduce.py
@@ -154,6 +154,14 @@ def clear_dataset(args):
     return api.clear_dataset(**vars(args))
 
 
+def list_api_keys(args):
+    return api.list_api_keys(**vars(args))
+
+
+def create_api_key(args):
+    return api.create_api_key(**vars(args))
+
+
 def set_api_key(args):
     if args.new == True:
         args.key = api.create_api_key(**vars(args))
@@ -319,6 +327,12 @@ def main():
     parser_config_find.add_argument('--content', help='Content to retreive: id,full,meta')
     parser_config_find.add_argument('--decode', action='store_true', help='Decode base64 and JSON for full content requests')
     parser_config_find.set_defaults(func=find_resource)
+
+    parser_list_api_keys = subparsers.add_parser('list-api-keys', parents=[api_cmd_parser], help='List API keys for your account')
+    parser_list_api_keys.set_defaults(func=list_api_keys)
+
+    parser_create_api_key = subparsers.add_parser('create-api-key', parents=[api_cmd_parser], help='Create an API key for your account')
+    parser_create_api_key.set_defaults(func=create_api_key)
 
     parser_create_dataset = subparsers.add_parser('create-dataset', parents=[api_cmd_parser], help='Create a Conduce dataset')
     parser_create_dataset.add_argument('name', help='The name to be given to the new dataset')

--- a/doc/source/api-key-creation.rst
+++ b/doc/source/api-key-creation.rst
@@ -4,7 +4,7 @@
 API Key Creation
 ====================
 
-API keys are used to authenticate requests made using the Conduce REST API.  API keys are created by the user and should be protected like passwords.  Anyone with an API key can make requests to Conduce and perform operations as the user who requested the key.
+API keys are used to authenticate requests made using the Conduce REST API.  API keys are created by the user and should be protected like passwords.  Anyone with an API key can make requests to Conduce and perform operations as the user who owns the key.
 
 Generally, there are three methods used to authenticate Conduce REST requests:
 
@@ -15,23 +15,46 @@ Generally, there are three methods used to authenticate Conduce REST requests:
 **API key**
     a unique string generated upon request that can be used to authenticate requests.
 
-In order to generate an API key, you must have a Conduce account.  Contact support@conduce.com if you do not already have an account.  Once your account is registered, you may create an API key.  It is easiest to do this using the Conduce command line utility.  Once you have :ref:`installed the Conduce Python API <https://github.com/ConduceInc/conduce-python-api>` execute the following command from your shell prompt::
+-------------------
+Generating API keys
+-------------------
 
-    conduce-api create-api-key --user=new_user@conduce.com --host=app.conduce.com
+In order to generate an API key, you must have a Conduce account.  Contact support@conduce.com if you do not already have an account.  Once your account is registered, you may create an API key.  It is easiest to do this using the Conduce command line utility.  Once you have installed the Conduce Python API from `GitHub <https://github.com/ConduceInc/conduce-python-api>`_ execute the following command from your shell prompt::
 
-After you submit your password, the new API key will be printed to the prompt and the command will finish.  Alternatively you may run a Python REPL and call :py:func:`api.create_api_key` directly.::
+    conduce-api create-api-key --user=<email_address> --host=app.conduce.com
+
+After entering the command you will be prompted for your password. After password submission, the new API key will be printed to the prompt and the command will finish.  Alternatively you may run a Python REPL and call :py:func:`api.create_api_key` directly.::
 
     import conduce
-    conduce.api.create_api_key(user="new_user@conduce.com", host="app.conduce.com")
+    conduce.api.create_api_key(user="<email_address>", host="app.conduce.com")
 
 Again, you will be prompted for your password.  Upon submission, the new API key will be written to the prompt.
 
 .. CAUTION::
     API keys can be used to perform any user operation.  This includes access to private data and personal information.  Be sure to protect API keys accordingly.
 
+
+-------------------
+Retreiving API keys
+-------------------
+
 API keys you have created may be retreived using the following command::
 
-    conduce-api list-api-keys --user=new_user@conduce.com host=app.conduce.com
+    conduce-api list-api-keys --user=<email_address> host=app.conduce.com
 
-The API keys and the date on which they were created will be printed to the terminal.  As with API creation.  The API keys may be listed using the Python API directly using :py:func:`api.list_api_keys`.
+The API keys and the date on which they were created will be printed to the terminal.  As with API creation, the API keys may be listed using the Python API directly using :py:func:`api.list_api_keys`.
 
+--------------
+Using API keys
+--------------
+
+Once you have created an API key you may now execute API calls without password authentication.  The API key is therefore a substitute for your username and password.  We can use an API key as follows::
+
+    conduce-api list-api-keys --api-key=<your-api-key> --host=app.conduce.com
+
+or::
+
+    import conduce
+    conduce.api.list_api_keys(api_key="<your-api-key>" host="app.conduce.com")
+
+API keys can be used in place of email addresses for all Conduce API requests.    

--- a/doc/source/api-key-creation.rst
+++ b/doc/source/api-key-creation.rst
@@ -1,0 +1,37 @@
+.. _api-key-creation:
+
+====================
+API Key Creation
+====================
+
+API keys are used to authenticate requests made using the Conduce REST API.  API keys are created by the user and should be protected like passwords.  Anyone with an API key can make requests to Conduce and perform operations as the user who requested the key.
+
+Generally, there are three methods used to authenticate Conduce REST requests:
+
+**username/password**
+    used to establish a session
+**session cookie**
+    returned from a user name password login.  Used to continue a session started with a username/password login.
+**API key**
+    a unique string generated upon request that can be used to authenticate requests.
+
+In order to generate an API key, you must have a Conduce account.  Contact support@conduce.com if you do not already have an account.  Once your account is registered, you may create an API key.  It is easiest to do this using the Conduce command line utility.  Once you have :ref:`installed the Conduce Python API <https://github.com/ConduceInc/conduce-python-api>` execute the following command from your shell prompt::
+
+    conduce-api create-api-key --user=new_user@conduce.com --host=app.conduce.com
+
+After you submit your password, the new API key will be printed to the prompt and the command will finish.  Alternatively you may run a Python REPL and call :py:func:`api.create_api_key` directly.::
+
+    import conduce
+    conduce.api.create_api_key(user="new_user@conduce.com", host="app.conduce.com")
+
+Again, you will be prompted for your password.  Upon submission, the new API key will be written to the prompt.
+
+.. CAUTION::
+    API keys can be used to perform any user operation.  This includes access to private data and personal information.  Be sure to protect API keys accordingly.
+
+API keys you have created may be retreived using the following command::
+
+    conduce-api list-api-keys --user=new_user@conduce.com host=app.conduce.com
+
+The API keys and the date on which they were created will be printed to the terminal.  As with API creation.  The API keys may be listed using the Python API directly using :py:func:`api.list_api_keys`.
+

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,7 +39,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.imgmath',
               'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode',
-              'sphinx.ext.githubpages']
+              'sphinx.ext.githubpages',
+              'm2r']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/getting-started.rst
+++ b/doc/source/getting-started.rst
@@ -1,0 +1,7 @@
+.. _getting-started:
+
+===============
+Getting Started
+===============
+
+.. mdinclude:: ../../README.md

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,9 +7,6 @@
 Conduce Python API
 ==================
 
-.. note::  This document is a work in progress.
-
-
 What's covered here
 -------------------
 Conduce is a data visualization platform design to enable users to integrate data from disparate systems and present them for analysis and discovery. The Python API provides users with a mechanism to ingest data, construct visualization components called lenses, and display those lenses on a two-dimensional substrate, like a map or floor plan, within the Conduce environment. This document provides a detailed description of the Python API and provides examples of its use.
@@ -19,7 +16,7 @@ Conduce is a data visualization platform design to enable users to integrate dat
    :maxdepth: 2
    :caption: Contents:
 
+   getting-started
+   conduce-entities
+   api-key-creation
    api-ref
-
-
-

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -9,7 +9,7 @@ Conduce Python API
 
 What's covered here
 -------------------
-Conduce is a data visualization platform design to enable users to integrate data from disparate systems and present them for analysis and discovery. The Python API provides users with a mechanism to ingest data, construct visualization components called lenses, and display those lenses on a two-dimensional substrate, like a map or floor plan, within the Conduce environment. This document provides a detailed description of the Python API and provides examples of its use.
+Conduce is a data visualization platform designed to enable users to integrate data from disparate systems and present them for analysis and discovery. The Python API provides users with a mechanism to ingest data, construct visualization components called lenses, and display those lenses on a two-dimensional substrate, like a map or floor plan, within the Conduce environment. This document provides a detailed description of the Python API and provides examples of its use.
 
 
 .. toctree::


### PR DESCRIPTION
This adds the documentation for creating api keys.  There is some cleanup work to be done in index.rst that is outside the scope of this story.

Please review this document:
https://conduce-conduce-python-api.readthedocs-hosted.com/en/feature-doc-create-api-key/api-key-creation.html 

and make comments here.

There are also code changes made to accommodate the documentation.

Exit criteria:

A non-Conduce expert can read this document and create an API key assuming they have a Conduce account and understand how to install a Python package.
