### PR TITLE
Convert ID field to string.

### DIFF
--- a/api.py
+++ b/api.py
@@ -461,7 +461,7 @@ def convert_samples_to_entity_set(sample_list):
         attributes = util.get_attributes(attribute_keys, sample)
 
         entities.append({
-            'identity': sample['id'],
+            'identity': str(sample['id']),
             'kind': sample['kind'],
             'timestamp_ms': util.datetime_to_timestamp_ms(sample['time']),
             'endtime_ms': util.datetime_to_timestamp_ms(sample['time']),


### PR DESCRIPTION
This change converts anything the user passes as an ID field to a string.  Any exceptions are raised to the user to handle.

This makes the code consistent with the example in "Conduce Entities" where integers are used as IDs.