### PR TITLE
Alex revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All CLI functionality is available through `conduce/api.py` and all API function
 As an example, you may list existing datasets with the following command:
 
 ```
-conduce-api list datasets --host=app.conduce.com --user=email@example.com --api-key=<your api key>
+conduce-api list datasets --host=app.conduce.com --user=email@example.com
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ The Conduce command line interface provides users with utilities for exercising 
 - Creating a dataset from a CSV or JSON file
 - Listing datasets and other resources
 
-```
 All CLI functionality is available through `conduce/api.py` and all API functionality should be usable with or without a `.conduceconfig` file. If you want to use the CLI without any setup you may fully specify your requests on the command line.
 
 As an example, you may list existing datasets with the following command:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import conduce
 ```
 Then you may use API functions, like `create_dataset` as follows:
 ```
-conduce.api.create_dataset('my-dataset-name', host='app.condcuce.com', user='email@example.com')
+conduce.api.create_dataset('my-dataset-name', host='app.conduce.com', user='email@example.com')
 ```
 However, this requires that the user authenticate with their password when the script is executed.  To avoid this, provide an `api-key` argument instead of `user`.  If you would like to learn more about API key creation, take a look at [API Key Creation](https://conduce-conduce-python-api.readthedocs-hosted.com/en/latest/api-key-creation.html).
 
@@ -51,6 +51,7 @@ The Conduce command line interface provides users with utilities for exercising 
 - Creating a dataset from a CSV or JSON file
 - Listing datasets and other resources
 
+```
 All CLI functionality is available through `conduce/api.py` and all API functionality should be usable with or without a `.conduceconfig` file. If you want to use the CLI without any setup you may fully specify your requests on the command line.
 
 As an example, you may list existing datasets with the following command:
@@ -87,7 +88,7 @@ or create an API key by adding the `--new` flag
 conduce-api config set api-key --new --user=valid_user --host=valid_host
 ```
 
-If you provide an API key for your default user and host you will never have to enter credentials to use that account as long as the API key is valid.
+If you configure an API key for your default user and host you will never have to enter credentials to use that account as long as the API key is valid.
 
 
 ## Conduce Configuration

--- a/README.md
+++ b/README.md
@@ -44,17 +44,24 @@ Other API features are documented in the [API Reference](https://conduce-conduce
 
 ## Getting started
 
-The Conduce command line interface provides users with utilities for exercising common API commands, and textual feedback for inspecting and debugging.  If you want to use the CLI without any setup you may fully specify your requests on the command line.
+The Conduce command line interface provides users with utilities for exercising common API commands, and textual feedback for inspecting and debugging. Features include:
+
+- Creating API keys
+- Adding and removing datasets
+- Creating a dataset from a CSV or JSON file
+- Listing datasets and other resources
+
+All CLI functionality is available through `conduce/api.py` and all API functionality should be usable with or without a `.conduceconfig` file. If you want to use the CLI without any setup you may fully specify your requests on the command line.
 
 As an example, you may list existing datasets with the following command:
 
 ```
-conduce-api list datasets --host=app.conduce.com --user=email@example.com
+conduce-api list datasets --host=app.conduce.com --user=email@example.com --api-key=<your api key>
 ```
 
 ## Setup
 
-You may omit the `host` and `user` arguments if you setup a configuration file.  You may do this by creating your own `~/.conduceconfig` and entering the configuration data, or by using the `config` subcommand:
+As mentioned above, rather than fully specifying every request, you can setup a `~/.conduceconfig` and entering the configuration data, or by using the `config` subcommand:
 
 To list configuration options and syntax:
 
@@ -81,17 +88,6 @@ conduce-api config set api-key --new --user=valid_user --host=valid_host
 ```
 
 If you provide an API key for your default user and host you will never have to enter credentials to use that account as long as the API key is valid.
-
-## Features
-
-The CLI provides many high level functions.  These include:
-
-- Creating API keys
-- Adding and removing datasets
-- Creating a dataset from a CSV or JSON file
-- Listing datasets and other resources
-
-All CLI functionality is available through `conduce/api.py` and all API functionality should be usable with or without a `.conduceconfig` file.
 
 
 ## Conduce Configuration

--- a/doc/source/api-key-creation.rst
+++ b/doc/source/api-key-creation.rst
@@ -4,7 +4,7 @@
 API Key Creation
 ====================
 
-API keys are used to authenticate requests made using the Conduce REST API.  They can be used in place of username/password authentication.  You may create as many API keys as you need, and you may wish to use different API keys for performing specific API operations.  API keys can also be used to grant other users temporary access to your account.
+API keys are used to authenticate requests made using the Conduce REST API.  They can be used in place of username/password authentication.  You may create as many API keys as you need, and may wish to use different API keys for performing specific API operations.  API keys can also be used to grant other users temporary access to your account.
 
 Generally, there are three methods used to authenticate Conduce REST requests:
 

--- a/doc/source/api-key-creation.rst
+++ b/doc/source/api-key-creation.rst
@@ -4,7 +4,7 @@
 API Key Creation
 ====================
 
-API keys provide a flexible mechanism for granting access to your account and are used to authenticate requests made using the Conduce REST API.  They can be used in place of username/password authentication.  You may create as many API keys as you need, and may wish to use different API keys for performing specific API operations.  API keys can also be used to grant other users temporary access to your account.
+API keys are used to authenticate requests made using the Conduce REST API.  They can be used in place of username/password authentication.  You may create as many API keys as you need, and you may wish to use different API keys for performing specific API operations.  API keys can also be used to grant other users temporary access to your account.
 
 Generally, there are three methods used to authenticate Conduce REST requests:
 

--- a/doc/source/api-key-creation.rst
+++ b/doc/source/api-key-creation.rst
@@ -4,7 +4,7 @@
 API Key Creation
 ====================
 
-API keys are used to authenticate requests made using the Conduce REST API.  They can be used in place of username/password authentication.  You may create as many API keys as you need, and may wish to use different API keys for performing specific API operations.  API keys can also be used to grant other users temporary access to your account.
+API keys provide a flexible mechanism for granting access to your account. They are used to authenticate requests made to the Conduce REST API in place of username/password authentication. You may create as many API keys as you need, and may wish to use different API keys for performing specific API operations.  API keys can also be used to grant other users temporary access to your account.
 
 Generally, there are three methods used to authenticate Conduce REST requests:
 

--- a/doc/source/api-key-creation.rst
+++ b/doc/source/api-key-creation.rst
@@ -4,7 +4,7 @@
 API Key Creation
 ====================
 
-API keys provide a flexible mechanism for granting access to your account. They are used to authenticate requests made to the Conduce REST API in place of username/password authentication. You may create as many API keys as you need, and may wish to use different API keys for performing specific API operations.  API keys can also be used to grant other users temporary access to your account.
+API keys provide a flexible mechanism for granting access to your account. They are used to authenticate requests made to the Conduce REST API as an alternative to username/password authentication. You may create as many API keys as you need, and may wish to use different API keys for performing specific API operations.  API keys can also be used to grant other users temporary access to your account.
 
 Generally, there are three methods used to authenticate Conduce REST requests:
 

--- a/doc/source/data-ingest.rst
+++ b/doc/source/data-ingest.rst
@@ -34,7 +34,7 @@ Datasets hold collections of related entities and provide the interface a user n
     world_cities_dataset = conduce.api.create_dataset('world cities', host='app.conduce.com', api-key='00000000-0000-0000-0000-000000000000')
     world_cities_dataset_id = world_cities_dataset['id']
 
-The dataset object retuned contains a dataset ID. This is a UUID which will be passed as a function parameter to the :py:func:`api.ingest_entities` function.
+The dataset object retuned contains a dataset ID such as '55611f65-c657-45b1-9d04-fe19227f6306'. This is a UUID which will be passed as a function parameter to the :py:func:`api.ingest_entities` function.
 
 If you want to ingest data into an existing dataset you will need to acquire its dataset ID.  Datasets are Conduce resources.  All resources have an ID and can be queried with the REST API.  The Conduce Python API provides a convenience method (:py:func:`api.list_datasets`) for listing datasets::
 

--- a/doc/source/data-ingest.rst
+++ b/doc/source/data-ingest.rst
@@ -31,9 +31,10 @@ Datasets hold collections of related entities and provide the interface a user n
 
 :py:func:`api.create_dataset`::
 
-    world_cities_dataset_id = conduce.api.create_dataset('world cities', host='app.conduce.com', api-key='00000000-0000-0000-0000-000000000000')
+    world_cities_dataset = conduce.api.create_dataset('world cities', host='app.conduce.com', api-key='00000000-0000-0000-0000-000000000000')
+    world_cities_dataset_id = world_cities_dataset['id']
 
-The dataset ID returned is a UUID.  It will be passed as a function parameter to the :py:func:`api.ingest_entities` function.
+The dataset object retuned contains a dataset ID. This is a UUID which will be passed as a function parameter to the :py:func:`api.ingest_entities` function.
 
 If you want to ingest data into an existing dataset you will need to acquire its dataset ID.  Datasets are Conduce resources.  All resources have an ID and can be queried with the REST API.  The Conduce Python API provides a convenience method (:py:func:`api.list_datasets`) for listing datasets::
 


### PR DESCRIPTION
two outstanding issues that I wasn't able to indicate with edits alone: 

1. when I make a conduce-api request without adding an API key manually, I don't get a password prompt as the documentation seems to indicate. Instead I just get an Authorization required error basically. I'm making a ticket for this. 

2. When to use ingest_samples vs ingest_entities is still a bit confusing. 
   i. An entity is a list of samples right? so why can't I use api.ingest_samples(dataset_id, entity,...) ? 
   ii. What do I do if some of the records I am adding are samples (part of an existing entity already in the dataset) and some are entities (haven't been seen before)? Is this allowed?
   iii. What if I don't know whether something is an entity or a sample? There might be more updates to this id coming along but I'm not sure. Sometimes I don't know if this entity exists in Conduce already. If its the first time, I suppose its an entity, but if not, its a sample. Is this correct? 