### PR TITLE
ignore case email check

### DIFF
--- a/acl.py
+++ b/acl.py
@@ -24,7 +24,7 @@ def get_user_id(email, users):
     if 'members' not in users:
         raise RuntimeError('No users in list')
     for user in users['members']:
-        if user['user']['email'] == email:
+        if user['user']['email'] == email.lower():
             return user['user']['id']
 
 
@@ -82,7 +82,7 @@ def build_groups(groups, team_id, **kwargs):
                     print 'Adding {} to team'.format(user['email'])
                     response = api.add_user_to_team(team_id, user['email'], **kwargs)
                     user_id = json.loads(response.content)['invite']['invitee']['id']
-                    #Update team members list since the user was added to the team
+                    # Update team members list since the user was added to the team
                     team_members = json.loads(api.list_team_members(team_id, **kwargs).content)
                 if user_id is not None and not user_in_group(user_id, group_members):
                     print 'Adding user {} to group {}'.format(user['email'], name)
@@ -93,7 +93,7 @@ def build_groups(groups, team_id, **kwargs):
                     response = api.create_account(user['name'], user['email'], **kwargs)
                     user_id = json.loads(response.content)['id']
                     api.add_user_to_team(team_id, user['email'], **kwargs)
-                    #Update team members list since the user was added to the team
+                    # Update team members list since the user was added to the team
                     team_members = json.loads(api.list_team_members(team_id, **kwargs).content)
                     api.add_user_to_group(team_id, group_id, user_id, **kwargs)
                 else:

--- a/acl.py
+++ b/acl.py
@@ -24,7 +24,7 @@ def get_user_id(email, users):
     if 'members' not in users:
         raise RuntimeError('No users in list')
     for user in users['members']:
-        if user['user']['email'] == email.lower():
+        if user['user']['email'].lower() == email.lower():
             return user['user']['id']
 
 


### PR DESCRIPTION
This change ensures that email address comparisons are done with lowercase characters.  It should be noted that this is in conflict with the standard:

>The local-part of a mailbox MUST BE treated as case sensitive.  Therefore, SMTP implementations MUST take care to preserve the case   of mailbox local-parts.  In particular, for some hosts, the user "smith" is different from the user "Smith".  However, exploiting the case sensitivity of mailbox local-parts impedes interoperability and is discouraged.  Mailbox domains follow normal DNS rules and are hence not case sensitive.
