### PR TITLE
Added command for creating resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="2.1.1",
-    description="Python Distribution Utilities",
+    version="2.2.0",
+    description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",
     url="https://www.conduce.com",


### PR DESCRIPTION
Also updated the package description.

This is a basic command for creating resources.  It assumes the user has a fully defined content file.  It does no content validation.

I tested it by creating a lens template with `samples/world-cities-lens.json`.  I was then able to edit the resource to add the dataset ID and make it valid.