### PR TITLE
Added example script that creates world cities lens

### DIFF
--- a/samples/create_world_cities.py
+++ b/samples/create_world_cities.py
@@ -1,0 +1,43 @@
+import sys
+sys.path.append('..')
+
+import api
+import util
+import acl
+import json
+
+
+def create_world_cities(args):
+    kwargs = vars(args)
+    print "Creating dataset"
+    dataset_meta = api.create_dataset('world-cities-data', **kwargs)
+    print "Ingesting data from CSV"
+    util.ingest_file(dataset_meta['id'], csv='simplemaps-worldcities-basic.csv', kind='city', answer_yes=True, generate_ids=True, **kwargs)
+    api.set_public_permissions(dataset_meta['id'], True, False, False, **kwargs)
+
+    with open('world-cities-lens.json', 'rb') as content_stream:
+        content = json.load(content_stream)
+        content['dataset_id'] = dataset_meta['id']
+        print "Creating lens"
+        lens_meta = api.create_template('world-cities', content, **kwargs)
+        api.set_public_permissions(lens_meta['id'], True, False, False, **kwargs)
+
+    print "Done."
+
+
+def main():
+    import argparse
+
+    arg_parser = argparse.ArgumentParser(description='Add the world-cities lens to an environment', formatter_class=argparse.RawTextHelpFormatter)
+
+    arg_parser.add_argument('--user', help='The user whose is making the request')
+    arg_parser.add_argument('--host', help='The server on which the command will run')
+    arg_parser.add_argument('--api-key', help='The API key used to authenticate')
+
+    args = arg_parser.parse_args()
+
+    create_world_cities(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/world-cities-lens.json
+++ b/samples/world-cities-lens.json
@@ -1,0 +1,57 @@
+{
+    "hover_info": [
+        {
+            "hoverable": true,
+            "html_template": "<style>\n.city {\nfont-size: 0.85em;\n}\n.province {\nfont-size: 0.75em;\n}\n.country {\nfont-size: 0.75em;\n}\n.population {\nfont-size: 0.5em;\n}\n</style>\n<div class='city'>{{attrs.city}}</div>\n<div class='province'>{{attrs.province}}</div>\n<div class='country'>{{attrs.country}}</div>\n<div class='population'>population: {{attrs.pop}}</div>",
+            "kinds": ["city"]
+        }
+    ],
+    "kinds": ["city"],
+    "name": "world-cities",
+    "renderer_service_name": "marker",
+    "renderings": [
+        {
+            "name": "city",
+            "point": [
+                {
+                    "defines": [
+                        { "shader_define_name": "SCALE_LOG" }
+                    ],
+                    "shader": {
+                        "fragment": { "uri": "dots/fragment.glsl" },
+                        "vertex": { "uri": "dots/vertex.glsl" }
+                    },
+                    "uniforms": [
+                        {
+                            "float_value": [0.1],
+                            "shader_uniform": "size_base",
+                            "type": "GL_FLOAT"
+                        },
+                        {
+                            "float_value": [2],
+                            "shader_uniform": "reference_zoom",
+                            "type": "GL_FLOAT"
+                        },
+                        {
+                            "shader_uniform": "color_base",
+                            "type": "GL_VEC4",
+                            "vec_value": [
+                                {
+                                    "w": 0.45490196,
+                                    "x": 0.0192,
+                                    "y": 0.63072,
+                                    "z": 0.96
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "rule": {
+                "kinds": ["city"],
+                "match": "ALL"
+            },
+            "use_high_precision_time": true
+        }
+    ]
+}


### PR DESCRIPTION
Create a dataset, ingest the world cities data, create a lens template that points to the data, and set public permissions to view the data.

This may be useful for populating deploys.  This works with an API key or one-time password authentication.