### PR TITLE
When a password is explicitly provided, it should override an existing API key

### DIFF
--- a/session.py
+++ b/session.py
@@ -14,7 +14,8 @@ def api_key_header(api_key):
 
 def get_session(host, email, password):
     api_key = config.get_api_key(email, host)
-    if api_key:
+    #If a password is provided, it should override the API key
+    if api_key and password is None:
         return api_key_header(api_key)
     cookies = None
     cookie_file_dir = os.path.join(os.path.expanduser('~'), '.conduce', host, email)


### PR DESCRIPTION
This allows for the creation of a new API key when the current key in the conduceconfig is invalid.

We were hitting this issue on deploy boxes.  Once a jenkins slave created an API key for a deploy, the config would be written with that key.  After the box is destroyed and the name reused, the deploy script could no longer generate a new API key because all attempts to do so would use the old (now invalid) API key stored in the config.

These precedence rules should be correct in general because a password provided by a user should be the overriding choice anyway.

We also should add some mechanism to remove an API key from conduceconfig, but that can be handled with future work.