### PR TITLE
SKW-2883: more robust waiting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="2.3.0",
+    version="2.4.0",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",


### PR DESCRIPTION
This changes adds more careful status checks while waiting for ingest jobs to complete.  After this change `wait_for_job` will not return on a 500 error.  It will retry.  The function should still return immediately on a 400 error.