### PR TITLE
SKW-3284: create tileset

### DIFF
--- a/api.py
+++ b/api.py
@@ -1076,6 +1076,7 @@ def create_resource(resource_type, resource_name, content, mime_type, **kwargs):
     resource_def = {
         'name': resource_name,
         'tags': kwargs.get('tags'),
+        'version': kwargs.get('version'),
         'type': resource_type,
         'mime': mime_type,
         'content': content

--- a/conduce.py
+++ b/conduce.py
@@ -315,6 +315,21 @@ def create_api_key(args):
     return api.create_api_key(**vars(args))
 
 
+def create_tileset(args):
+    if args.tile_json:
+        raise "TileJSON not currently supported by the CLI"
+
+    if args.style_url.split('mapbox://styles/')[1] < 2:
+        raise ValueError('Style URL must be a Mapbox style URL')
+
+    content = {
+        'url': args.style_url,
+        'style': args.style_url.split('mapbox://styles/')[1]
+    }
+
+    return api.create_json_resource('TILESET', args.name, content, version=2, **vars(args))
+
+
 def remove_api_key(args):
     key = args.key
     del vars(args)['key']
@@ -577,6 +592,12 @@ def main():
     parser_create_dataset.add_argument('--answer-yes', help='Set this flag to answer yes at all prompts', action='store_true')
     parser_create_dataset.add_argument('--debug', help='Get better information about errors', action='store_true')
     parser_create_dataset.set_defaults(func=create_dataset)
+
+    parser_create_tileset = subparsers.add_parser('create-tileset', parents=[api_cmd_parser], help='Create a Conduce tileset')
+    parser_create_tileset.add_argument('name', help='The name to be given to the new tileset')
+    parser_create_tileset.add_argument('--style-url', help='The Mapbox URL used to access the style <mapbox://styles/...>')
+    parser_create_tileset.add_argument('--tile-json', help='A valid TileJSON file')
+    parser_create_tileset.set_defaults(func=create_tileset)
 
     parser_ingest_data = subparsers.add_parser('ingest-data', parents=[api_cmd_parser], help='Ingest data to a Conduce dataset')
     parser_ingest_data.add_argument('dataset_id', help='The ID of the dataset to receive the entities')

--- a/conduce.py
+++ b/conduce.py
@@ -106,7 +106,11 @@ def find_resource(args):
         if args.content == 'full':
             for resource in resources:
                 if resource.get('mime', 'invalid-mime') == 'application/json':
-                    resource['content'] = json.loads(resource['content'])
+                    if 'content' in resource:
+                        try:
+                            resource['content'] = json.loads(resource['content'])
+                        except:
+                            print('Could not decode content for {}'.format(resource['id']))
                 elif not resource.get('mime', 'invalid-mime').startswith('text/'):
                     resource['content'] = base64.b64decode(resource['content'])
 

--- a/conduce.py
+++ b/conduce.py
@@ -324,7 +324,8 @@ def create_tileset(args):
 
     content = {
         'url': args.style_url,
-        'style': args.style_url.split('mapbox://styles/')[1]
+        'style': args.style_url.split('mapbox://styles/')[1],
+        'accessToken': args.access_token,
     }
 
     return api.create_json_resource('TILESET', args.name, content, version=2, **vars(args))
@@ -596,6 +597,7 @@ def main():
     parser_create_tileset = subparsers.add_parser('create-tileset', parents=[api_cmd_parser], help='Create a Conduce tileset')
     parser_create_tileset.add_argument('name', help='The name to be given to the new tileset')
     parser_create_tileset.add_argument('--style-url', help='The Mapbox URL used to access the style <mapbox://styles/...>')
+    parser_create_tileset.add_argument('--access-token', help='Mapbox access token. Use for user owned private map styles.')
     parser_create_tileset.add_argument('--tile-json', help='A valid TileJSON file')
     parser_create_tileset.set_defaults(func=create_tileset)
 

--- a/setup.py
+++ b/setup.py
@@ -6,16 +6,16 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 
 setup(
-        name="conduce",
-        version="2.4.1",
-        description="Conduce Python API",
-        author="Conduce",
-        author_email="support@conduce.com",
-        url="https://www.conduce.com",
-        install_requires=required,
-        packages=["conduce"],
-        package_dir={"conduce": ""},
-        entry_points={
+    name="conduce",
+    version="2.5.1",
+    description="Conduce Python API",
+    author="Conduce",
+    author_email="support@conduce.com",
+    url="https://www.conduce.com",
+    install_requires=required,
+    packages=["conduce"],
+    package_dir={"conduce": ""},
+    entry_points={
             "console_scripts": ["conduce-api=conduce.conduce:main"],
-            },
-        )
+    },
+)


### PR DESCRIPTION
Adds a CLI command to create a tileset.  User provides the mapbox url to the tileset definition.

Necessary to support a documented way to add a tileset.