### PR TITLE
apikey uris have api in them

### DIFF
--- a/api.py
+++ b/api.py
@@ -149,7 +149,7 @@ def wait_for_job(job_id, **kwargs):
 
 
 def compose_uri(fragment):
-    if not 'api' in fragment:
+    if not 'api/v' in fragment:
         prefix = 'conduce/api/v1'
         fragment = fragment.lstrip('/')
         uri = '{}'.format(fragment)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="2.5.1",
+    version="2.5.2",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",


### PR DESCRIPTION
The `compose_uri` method was checking for "api" in the URI fragment and assuming it was a complete URI if the string was present.  Doesn't seem like the greatest check.

This is a quick fix to make the `apikeys/list` URI work again.