### PR TITLE
Added support for hard delete

### DIFF
--- a/api.py
+++ b/api.py
@@ -861,7 +861,7 @@ def remove_resource(**kwargs):
     kwargs['all'] = kwargs.get('all')
 
     if kwargs['id']:
-        _remove_resource(kwargs['id'], **kwargs)
+        return_message = _remove_resource(kwargs['id'], **kwargs)
     elif kwargs['name'] or kwargs['regex'] or kwargs['name'] == "" or kwargs.get('no_name'):
         results = find_resource(**kwargs)
         to_remove = []

--- a/conduce.py
+++ b/conduce.py
@@ -300,7 +300,7 @@ def remove_resource(args):
 
 
 def remove_dataset(args):
-    return api.remove_dataset(**vars(args))
+    return api.remove_dataset(permanent=args.hard, **vars(args))
 
 
 def clear_dataset(args):
@@ -704,10 +704,11 @@ def main():
     parser_clear_dataset.add_argument('--all', help='clear all matching datasets', action='store_true')
     parser_clear_dataset.set_defaults(func=clear_dataset)
 
-    parser_remove_dataset = subparsers.add_parser('remove-dataset', parents=[api_cmd_parser], help='Remove a dataset from Conduce')
+    parser_remove_dataset = subparsers.add_parser('remove-dataset', parents=[api_cmd_parser], help='Remove a dataset from Conduce (soft delete)')
     parser_remove_dataset.add_argument('--id', help='The ID of the dataset to be removed')
     parser_remove_dataset.add_argument('--name', help='The name of the dataset to be removed')
     parser_remove_dataset.add_argument('--regex', help='Remove datasets that match the regular expression')
+    parser_remove_dataset.add_argument('--hard', action='store_true', help='Permanently destroy (hard delete) the dataset')
     parser_remove_dataset.add_argument('--all', help='Remove all matching datasets', action='store_true')
     parser_remove_dataset.set_defaults(func=remove_dataset)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="2.5.2",
+    version="2.6.0",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",


### PR DESCRIPTION
Adds support for hard delete (permanent=true) via the `--hard` flag.

Also fixes a bug that prevented headers from being printed after a `remove_resource` call.