### PR TITLE
CLI tagging support

### DIFF
--- a/api.py
+++ b/api.py
@@ -868,11 +868,11 @@ def remove_resource(**kwargs):
 
     if kwargs['id']:
         return_message = _remove_resource(kwargs['id'], **kwargs)
-    elif kwargs['name'] or kwargs['regex'] or kwargs['name'] == "" or kwargs.get('no_name'):
+    elif kwargs['name'] or kwargs['regex'] or kwargs['name'] == "" or kwargs.get('no_name') or kwargs.get('tags'):
         results = find_resource(**kwargs)
         to_remove = []
         for resource_obj in results:
-            if (resource_obj.get('name') is not None and (resource_obj['name'] == kwargs['name']) or (resource_obj.get('name') is None and kwargs.get('no_name', False) is True) or (kwargs['regex'] and re.match(kwargs['regex'], resource_obj['name']))):
+            if (resource_obj.get('name') is not None and (resource_obj['name'] == kwargs['name']) or (resource_obj.get('name') is None and kwargs.get('no_name', False) is True) or (kwargs['regex'] and re.match(kwargs['regex'], resource_obj['name'])) or (kwargs.get('tags') is not None and set(kwargs.get('tags')) < set(resource_obj['tags']))):
                 to_remove.append(resource_obj)
         if len(to_remove) == 1:
             _remove_resource(to_remove[0]['id'], **kwargs)
@@ -885,8 +885,8 @@ def remove_resource(**kwargs):
         elif len(to_remove) > 1:
             return_message = "Matching {}:\n".format(resource_type)
             return_message += json.dumps(to_remove)
-            return_message += "\n\nName or regular expression matched multiple {}.  Pass --all to remove all matching {}.".format(
-                resource_type, resource_type)
+            return_message += "\n\nName or regular expression matched {} {}.  Pass --all to remove all matching {}.".format(
+                len(to_remove), resource_type, resource_type)
         else:
             return_message = "No matching {} found.".format(resource_type)
     else:
@@ -1501,6 +1501,24 @@ def _modify_resource_content(resource_id, content, mime_type, **kwargs):
     resource = get_resource(resource_id, **kwargs)
     resource['content'] = content
     resource['mime'] = mime_type
+    update_resource(resource, **kwargs)
+
+
+def set_tags(resource_id, tags, **kwargs):
+    resource = get_resource(resource_id, **kwargs)
+    resource['tags'] = tags
+    update_resource(resource, **kwargs)
+
+
+def add_tags(resource_id, tags, **kwargs):
+    resource = get_resource(resource_id, **kwargs)
+    resource['tags'] += tags
+    update_resource(resource, **kwargs)
+
+
+def remove_tags(resource_id, tags, **kwargs):
+    resource = get_resource(resource_id, **kwargs)
+    resource['tags'] = [tag for tag in resource['tags'] if tag not in tags]
     update_resource(resource, **kwargs)
 
 

--- a/asset.py
+++ b/asset.py
@@ -32,7 +32,7 @@ def initialize_asset(name, data, mime_type, **kwargs):
         print('Created asset {} {}'.format(name, asset_id))
     else:
         asset_id = found[0]['id']
-        print ('Found asset {} {}'.format(name, asset_id))
+        print('Found asset {} {}'.format(name, asset_id))
         api.modify_asset_content(asset_id, data, mime_type, **kwargs)
         print('Updated asset {} {}'.format(name, asset_id))
 

--- a/asset.py
+++ b/asset.py
@@ -10,7 +10,8 @@ def initialize_binary_asset(path, **kwargs):
         image = image_stream.read()
 
         name = kwargs.get('name', os.path.basename(path))
-        del kwargs['name']
+        if 'name' in kwargs:
+            del kwargs['name']
         return initialize_asset(name, image, mime, **kwargs)
 
 
@@ -20,7 +21,7 @@ def initialize_asset(name, data, mime_type, **kwargs):
 
     if asset_id is not None:
         api.modify_asset_content(asset_id, data, mime_type, **kwargs)
-        print 'Updated asset {} {}'.format(name, asset_id)
+        print('Updated asset {} {}'.format(name, asset_id))
         return asset_id
 
     if kwargs.get('modify'):
@@ -28,11 +29,11 @@ def initialize_asset(name, data, mime_type, **kwargs):
 
     if len(found) == 0:
         asset_id = api.create_asset(name, data, mime_type, **kwargs)['id']
-        print 'Created asset {} {}'.format(name, asset_id)
+        print('Created asset {} {}'.format(name, asset_id))
     else:
         asset_id = found[0]['id']
-        print 'Found asset {} {}'.format(name, asset_id)
+        print ('Found asset {} {}'.format(name, asset_id))
         api.modify_asset_content(asset_id, data, mime_type, **kwargs)
-        print 'Updated asset {} {}'.format(name, asset_id)
+        print('Updated asset {} {}'.format(name, asset_id))
 
     return asset_id

--- a/conduce.py
+++ b/conduce.py
@@ -299,6 +299,26 @@ def remove_resource(args):
     return api.remove_resource(**vars(args))
 
 
+def tag_resource(args):
+    tags = vars(args).pop('tags')
+    set_tags = vars(args).pop('set')
+    remove_tags = vars(args).pop('remove')
+
+    if args.type is not None:
+        args.type = format_resource_type(args.type)
+
+    resources = api.find_resource(**vars(args))
+
+    print(resources)
+    for resource in resources:
+        if set_tags:
+            api.set_tags(resource['id'], tags, **vars(args))
+        elif remove_tags:
+            api.remove_tags(resource['id'], tags, **vars(args))
+        else:
+            api.add_tags(resource['id'], tags, **vars(args))
+
+
 def remove_dataset(args):
     return api.remove_dataset(permanent=args.hard, **vars(args))
 
@@ -538,6 +558,7 @@ def main():
     parser_find.add_argument('--content', help='Content to retrieve: id,full,meta')
     parser_find.add_argument('--decode', action='store_true', help='Decode base64 and JSON for full content requests')
     parser_find.add_argument('--no-name', action='store_true', help='Match resources with no name')
+    parser_find.add_argument('--tags', type=str, nargs='+', help='Match resources with the specified tag')
     parser_find.set_defaults(func=find_resource)
 
     parser_dataset = subparsers.add_parser('dataset', help='Conduce dataset operations')
@@ -718,8 +739,20 @@ def main():
     parser_remove.add_argument('--name', help='The name of the resource to be removed')
     parser_remove.add_argument('--regex', help='Remove resources that match the regular expression')
     parser_remove.add_argument('--no-name', action='store_true', help='Match resources with no name')
+    parser_remove.add_argument('--tags', nargs='+', help='Match resources with specified tag')
     parser_remove.add_argument('--all', help='Remove all matching resources', action='store_true')
     parser_remove.set_defaults(func=remove_resource)
+
+    parser_tag = subparsers.add_parser('tag', parents=[api_cmd_parser], help='Add tag to resources that match the given parameters')
+    parser_tag.add_argument('tags', nargs='+', help='The tag or tags to be applied to the matched resource(s) (separated by spaces)')
+    parser_tag.add_argument('--id', help='The ID of the resource to be tagged')
+    parser_tag.add_argument('--type', help='Conduce resource type to tag')
+    parser_tag.add_argument('--name', help='The name of the resource to be tagged')
+    parser_tag.add_argument('--regex', help='tag resources that match the regular expression')
+    parser_tag.add_argument('--no-name', action='store_true', help='Match resources with no name')
+    parser_tag.add_argument('--remove', action='store_true', help='Remove tags instead of adding')
+    parser_tag.add_argument('--set', action='store_true', help='Set the list of tags to the specified')
+    parser_tag.set_defaults(func=tag_resource)
 
     parser_permissions = subparsers.add_parser('permissions', help='Conduce permissions operations')
     parser_permissions_subparsers = parser_permissions.add_subparsers(help='permissions subcommands')

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="2.7.0",
+    version="2.8.0",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",


### PR DESCRIPTION
Now users can add/remove/set tags via command line arguments.  Users can also search and remove by tag.

Multiple tags may be specified by providing multiple `--tags` arguments.