### PR TITLE
Don't raise exception on numbers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="2.8.0",
+    version="2.8.1",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",

--- a/util.py
+++ b/util.py
@@ -7,6 +7,7 @@ from dateutil import parser
 import copy
 import api
 import pytz
+import math
 import sys
 
 
@@ -99,7 +100,7 @@ def csv_to_json(infile, outfile=None, toStdout=False, **kwargs):
         if toStdout is True:
             print out
             print
-        if not outfile is None:
+        if outfile is not None:
             with open(outfile, "w") as output_file:
                 json.dump(out, output_file)
 
@@ -118,7 +119,7 @@ def get_id_score(key, value):
     try:
         if float.is_integer(float(value)):
             score += 100
-            if not '.' in value:
+            if '.' not in value:
                 score += 300
     except:
         pass
@@ -267,7 +268,7 @@ def build_attribute(key, value):
     attribute = {'key': key}
     try:
         float_val = float(value)
-        if float_val.isinf() or float_val.isnan():
+        if math.isinf(float_val) or math.isnan(float_val):
             raise RuntimeError('This value should be parsed as a string')
         if float.is_integer(float_val):
             attribute['type'] = 'INT64'


### PR DESCRIPTION
Invalid syntax caused type checks to fail in all cases.  It went unnoticed because the exception was caught and the attributes were parsed as strings.

This bug would impact production for any ingest daemon that calls `dict_to_entities`.