### PR TITLE
Add --no-verify option to ignore SSL certificate errors

### DIFF
--- a/api.py
+++ b/api.py
@@ -195,7 +195,7 @@ def _make_delete_request(uri, **kwargs):
         password = kwargs['password']
     else:
         password = None
-    if 'noverify' in kwargs and kwargs['noverify']:
+    if 'no_verify' in kwargs and kwargs['no_verify']:
         verify=False
     else:
         verify=True
@@ -302,7 +302,7 @@ def _make_get_request(uri, **kwargs):
     else:
         password = None
 
-    if 'noverify' in kwargs and kwargs['noverify']:
+    if 'no_verify' in kwargs and kwargs['no_verify']:
         verify = False
     else:
         verify = True
@@ -1274,7 +1274,7 @@ def _make_post_request(payload, uri, **kwargs):
     else:
         password = None
 
-    if 'noverify' in kwargs and kwargs['noverify']:
+    if 'no_verify' in kwargs and kwargs['no_verify']:
         verify = False
     else:
         verify = True
@@ -1357,7 +1357,7 @@ def _make_put_request(payload, uri, **kwargs):
     else:
         password = None
 
-    if 'noverify' in kwargs and kwargs['noverify']:
+    if 'no_verify' in kwargs and kwargs['no_verify']:
         verify=False
     else:
         verify=True
@@ -1440,7 +1440,7 @@ def _make_patch_request(payload, uri, **kwargs):
     else:
         password = None
 
-    if 'noverify' in kwargs and kwargs['noverify']:
+    if 'no_verify' in kwargs and kwargs['no_verify']:
         verify=False
     else:
         verify=True

--- a/api.py
+++ b/api.py
@@ -195,6 +195,10 @@ def _make_delete_request(uri, **kwargs):
         password = kwargs['password']
     else:
         password = None
+    if 'noverify' in kwargs and kwargs['noverify']:
+        verify=False
+    else:
+        verify=True
 
     if 'api_key' in kwargs and kwargs['api_key']:
         auth = session.api_key_header(kwargs['api_key'])
@@ -207,9 +211,9 @@ def _make_delete_request(uri, **kwargs):
 
     url = 'https://{}/{}'.format(host, uri)
     if 'Authorization' in auth:
-        response = requests.delete(url, headers=auth)
+        response = requests.delete(url, headers=auth, verify=verify)
     else:
-        response = requests.delete(url, cookies=auth)
+        response = requests.delete(url, cookies=auth, verify=verify)
     response.raise_for_status()
     return response
 
@@ -298,6 +302,11 @@ def _make_get_request(uri, **kwargs):
     else:
         password = None
 
+    if 'noverify' in kwargs and kwargs['noverify']:
+        verify = False
+    else:
+        verify = True
+
     if 'api_key' in kwargs and kwargs['api_key']:
         auth = session.api_key_header(kwargs['api_key'])
     else:
@@ -309,9 +318,9 @@ def _make_get_request(uri, **kwargs):
 
     url = 'https://{}/{}'.format(host, uri)
     if 'Authorization' in auth:
-        response = requests.get(url, headers=auth)
+        response = requests.get(url, headers=auth, verify=verify)
     else:
-        response = requests.get(url, cookies=auth)
+        response = requests.get(url, cookies=auth, verify=verify)
     response.raise_for_status()
     return response
 
@@ -1274,6 +1283,11 @@ def _make_post_request(payload, uri, **kwargs):
             user = cfg['default-user']
         auth = session.get_session(host, user, password)
 
+    if 'noverify' in kwargs and kwargs['noverify']:
+        verify = False
+    else:
+        verify = True
+
     headers = {}
     url = 'https://{}/{}'.format(host, uri)
     if 'Authorization' in auth:
@@ -1283,9 +1297,9 @@ def _make_post_request(payload, uri, **kwargs):
         else:
             headers = auth
 
-        response = requests.post(url, json=payload, headers=headers)
+        response = requests.post(url, json=payload, headers=headers, verify=verify)
     else:
-        response = requests.post(url, json=payload, cookies=auth, headers=headers)
+        response = requests.post(url, json=payload, cookies=auth, headers=headers, verify=verify)
 
     response.raise_for_status()
     return response
@@ -1352,6 +1366,11 @@ def _make_put_request(payload, uri, **kwargs):
             user = cfg['default-user']
         auth = session.get_session(host, user, password)
 
+    if 'noverify' in kwargs and kwargs['noverify']:
+        verify=False
+    else:
+        verify=True
+
     headers = {}
     url = 'https://{}/{}'.format(host, uri)
     if 'Authorization' in auth:
@@ -1361,9 +1380,9 @@ def _make_put_request(payload, uri, **kwargs):
         else:
             headers = auth
 
-        response = requests.put(url, json=payload, headers=headers)
+        response = requests.put(url, json=payload, headers=headers, verify=verify)
     else:
-        response = requests.put(url, json=payload, cookies=auth, headers=headers)
+        response = requests.put(url, json=payload, cookies=auth, headers=headers, verify=verify)
 
     response.raise_for_status()
     return response
@@ -1430,6 +1449,11 @@ def _make_patch_request(payload, uri, **kwargs):
             user = cfg['default-user']
         auth = session.get_session(host, user, password)
 
+    if 'noverify' in kwargs and kwargs['noverify']:
+        verify=False
+    else:
+        verify=True
+
     headers = {}
     url = 'https://{}/{}'.format(host, uri)
     if 'Authorization' in auth:
@@ -1439,9 +1463,9 @@ def _make_patch_request(payload, uri, **kwargs):
         else:
             headers = auth
 
-        response = requests.patch(url, json=payload, headers=headers)
+        response = requests.patch(url, json=payload, headers=headers, verify=verify)
     else:
-        response = requests.patch(url, json=payload, cookies=auth, headers=headers)
+        response = requests.patch(url, json=payload, cookies=auth, headers=headers, verify=verify)
 
     response.raise_for_status()
     return response

--- a/api.py
+++ b/api.py
@@ -207,7 +207,7 @@ def _make_delete_request(uri, **kwargs):
             user = kwargs['user']
         else:
             user = cfg['default-user']
-        auth = session.get_session(host, user, password)
+        auth = session.get_session(host, user, password, verify)
 
     url = 'https://{}/{}'.format(host, uri)
     if 'Authorization' in auth:
@@ -314,7 +314,7 @@ def _make_get_request(uri, **kwargs):
             user = kwargs['user']
         else:
             user = cfg['default-user']
-        auth = session.get_session(host, user, password)
+        auth = session.get_session(host, user, password, verify)
 
     url = 'https://{}/{}'.format(host, uri)
     if 'Authorization' in auth:
@@ -1274,6 +1274,11 @@ def _make_post_request(payload, uri, **kwargs):
     else:
         password = None
 
+    if 'noverify' in kwargs and kwargs['noverify']:
+        verify = False
+    else:
+        verify = True
+
     if 'api_key' in kwargs and kwargs['api_key']:
         auth = session.api_key_header(kwargs['api_key'])
     else:
@@ -1281,12 +1286,7 @@ def _make_post_request(payload, uri, **kwargs):
             user = kwargs['user']
         else:
             user = cfg['default-user']
-        auth = session.get_session(host, user, password)
-
-    if 'noverify' in kwargs and kwargs['noverify']:
-        verify = False
-    else:
-        verify = True
+        auth = session.get_session(host, user, password, verify)
 
     headers = {}
     url = 'https://{}/{}'.format(host, uri)
@@ -1357,6 +1357,11 @@ def _make_put_request(payload, uri, **kwargs):
     else:
         password = None
 
+    if 'noverify' in kwargs and kwargs['noverify']:
+        verify=False
+    else:
+        verify=True
+
     if 'api_key' in kwargs and kwargs['api_key']:
         auth = session.api_key_header(kwargs['api_key'])
     else:
@@ -1364,12 +1369,7 @@ def _make_put_request(payload, uri, **kwargs):
             user = kwargs['user']
         else:
             user = cfg['default-user']
-        auth = session.get_session(host, user, password)
-
-    if 'noverify' in kwargs and kwargs['noverify']:
-        verify=False
-    else:
-        verify=True
+        auth = session.get_session(host, user, password, verify)
 
     headers = {}
     url = 'https://{}/{}'.format(host, uri)
@@ -1440,6 +1440,11 @@ def _make_patch_request(payload, uri, **kwargs):
     else:
         password = None
 
+    if 'noverify' in kwargs and kwargs['noverify']:
+        verify=False
+    else:
+        verify=True
+
     if 'api_key' in kwargs and kwargs['api_key']:
         auth = session.api_key_header(kwargs['api_key'])
     else:
@@ -1447,12 +1452,7 @@ def _make_patch_request(payload, uri, **kwargs):
             user = kwargs['user']
         else:
             user = cfg['default-user']
-        auth = session.get_session(host, user, password)
-
-    if 'noverify' in kwargs and kwargs['noverify']:
-        verify=False
-    else:
-        verify=True
+        auth = session.get_session(host, user, password, verify)
 
     headers = {}
     url = 'https://{}/{}'.format(host, uri)

--- a/conduce.py
+++ b/conduce.py
@@ -506,7 +506,7 @@ def main():
     api_cmd_parser.add_argument('--user', help='The user whose is making the request')
     api_cmd_parser.add_argument('--host', help='The server on which the command will run')
     api_cmd_parser.add_argument('--api-key', help='The API key used to authenticate')
-    api_cmd_parser.add_argument('--noverify', action='store_true', help='If passed, the SSL certificate of the host will not be verified')
+    api_cmd_parser.add_argument('--no-verify', action='store_true', help='If passed, the SSL certificate of the host will not be verified')
 
     subparsers = arg_parser.add_subparsers(help='help for subcommands')
 

--- a/conduce.py
+++ b/conduce.py
@@ -506,6 +506,7 @@ def main():
     api_cmd_parser.add_argument('--user', help='The user whose is making the request')
     api_cmd_parser.add_argument('--host', help='The server on which the command will run')
     api_cmd_parser.add_argument('--api-key', help='The API key used to authenticate')
+    api_cmd_parser.add_argument('--noverify', action='store_true', help='If passed, the SSL certificate of the host will not be verified')
 
     subparsers = arg_parser.add_subparsers(help='help for subcommands')
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = python2 -msphinx
 SPHINXPROJ    = ConducePythonAPI
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python2 -msphinx
+SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = ConducePythonAPI
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/session.py
+++ b/session.py
@@ -12,7 +12,7 @@ def api_key_header(api_key):
     return {'Authorization': 'Bearer {}'.format(api_key)}
 
 
-def get_session(host, email, password):
+def get_session(host, email, password, verify=True):
     api_key = config.get_api_key(email, host)
     if api_key and password is None:
         return api_key_header(api_key)
@@ -29,22 +29,22 @@ def get_session(host, email, password):
     except:
         pass
 
-    if cookies is None or not validate_session(host, cookies):
+    if cookies is None or not validate_session(host, cookies, verify):
         if password is None:
             print
             print "host: {}".format(host)
             print "user: {}".format(email)
             password = getpass.getpass()
 
-        cookies = login(host, email, password)
+        cookies = login(host, email, password, verify)
         with open(cookie_file_path, 'w') as cookie_file:
             pickle.dump(requests.utils.dict_from_cookiejar(cookies), cookie_file)
 
     return cookies
 
 
-def validate_session(host, cookies):
-    response = requests.get("https://{}/conduce/api/v1/user/validate-session".format(host), cookies=cookies)
+def validate_session(host, cookies, verify):
+    response = requests.get("https://{}/conduce/api/v1/user/validate-session".format(host), cookies=cookies, verify=verify)
     if response.status_code == 401:
         print "Session expired"
         cookies = None
@@ -53,7 +53,7 @@ def validate_session(host, cookies):
     return cookies
 
 
-def login(host, email, password):
+def login(host, email, password, verify):
     if email is None:
         raise Exception('No user provided for login')
     if password is None:
@@ -63,7 +63,7 @@ def login(host, email, password):
         "email": email,
         "password": password,
         "keep": False,
-        })
+        }, verify=verify)
     response.raise_for_status()
     return response.cookies
 
@@ -77,6 +77,7 @@ if __name__ == '__main__':
     arg_parser.add_argument('--user', help='Email address of user making request')
     arg_parser.add_argument('--password', help='The password of the user making the request')
     arg_parser.add_argument('--api-key', help='API key used to authenticate')
+    arg_parser.add_argument('--noverify', action='store_true', help='If passed, the SSL certificate of the host will not be verified')
 
     args = arg_parser.parse_args()
 
@@ -84,4 +85,9 @@ if __name__ == '__main__':
     if email is None:
         email = "dhl-dev@conduce.com"
 
-    print get_session(args.host, email, password)
+    if args.noverify:
+        verify = False
+    else:
+        verify = True
+
+    print get_session(args.host, email, args.password, verify)

--- a/session.py
+++ b/session.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     arg_parser.add_argument('--user', help='Email address of user making request')
     arg_parser.add_argument('--password', help='The password of the user making the request')
     arg_parser.add_argument('--api-key', help='API key used to authenticate')
-    arg_parser.add_argument('--noverify', action='store_true', help='If passed, the SSL certificate of the host will not be verified')
+    arg_parser.add_argument('--no-verify', action='store_true', help='If passed, the SSL certificate of the host will not be verified')
 
     args = arg_parser.parse_args()
 
@@ -85,7 +85,7 @@ if __name__ == '__main__':
     if email is None:
         email = "dhl-dev@conduce.com"
 
-    if args.noverify:
+    if args.no_verify:
         verify = False
     else:
         verify = True

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="2.8.1",
+    version="2.8.2",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",


### PR DESCRIPTION
Self-signed SSL certificates fail verification.  This PR adds a
--noverify command line flag to the conduce api utility to skip SSL
certificate verification.