### PR TITLE
Add --no-verify to create_world_cities script

### DIFF
--- a/samples/create_world_cities.py
+++ b/samples/create_world_cities.py
@@ -41,6 +41,7 @@ def main():
     arg_parser.add_argument('--user', help='The user whose is making the request')
     arg_parser.add_argument('--host', help='The server on which the command will run')
     arg_parser.add_argument('--api-key', help='The API key used to authenticate')
+    arg_parser.add_argument('--no-verify', action='store_true', help='If passed, the SSL certificate of the host will not be verified')
 
     args = arg_parser.parse_args()
 


### PR DESCRIPTION
Add --no-verify option to the create_world_cities.py script.  Since args get
passed down directly to the python conduce api calls, this will allow
this script to connect a self-signed SSL certificate.