### PR TITLE
Update Requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ requests
 retrying
 python-dateutil
 pytz
-pyyaml
+pyyaml>=5.1


### PR DESCRIPTION
Specify min version of pyyaml needed to use the correct loader option,
otherwise a previously installed older version may satisfy the
requirement, even when specifying --upgrade.