### PR TITLE
add option to display only name: id in find list

### DIFF
--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -142,6 +142,9 @@ def find_resource(args):
                 elif not resource.get('mime', 'invalid-mime').startswith('text/'):
                     resource['content'] = base64.b64decode(resource['content'])
 
+    if args.short:
+        return list(map((lambda x: "{}: {}".format(x['name'], x['id'])), resources))
+
     return resources
 
 
@@ -610,6 +613,7 @@ def main():
     parser_find.add_argument('--content', help='Content to retrieve: id,full,meta')
     parser_find.add_argument('--decode', action='store_true', help='Decode base64 and JSON for full content requests')
     parser_find.add_argument('--no-name', action='store_true', help='Match resources with no name')
+    parser_find.add_argument('-s', '--short', action='store_true', help='Return only names and IDs')
     parser_find.add_argument('--tags', type=str, nargs='+', help='Match resources with the specified tag')
     parser_find.set_defaults(func=find_resource)
 

--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -142,7 +142,7 @@ def find_resource(args):
                 elif not resource.get('mime', 'invalid-mime').startswith('text/'):
                     resource['content'] = base64.b64decode(resource['content'])
 
-    if args.short:
+    if args.one_line:
         return list(map((lambda x: "{}: {}".format(x['name'], x['id'])), resources))
 
     return resources
@@ -613,7 +613,7 @@ def main():
     parser_find.add_argument('--content', help='Content to retrieve: id,full,meta')
     parser_find.add_argument('--decode', action='store_true', help='Decode base64 and JSON for full content requests')
     parser_find.add_argument('--no-name', action='store_true', help='Match resources with no name')
-    parser_find.add_argument('-s', '--short', action='store_true', help='Return only names and IDs')
+    parser_find.add_argument('-1', '--one-line', action='store_true', help='Return only names and IDs')
     parser_find.add_argument('--tags', type=str, nargs='+', help='Match resources with the specified tag')
     parser_find.set_defaults(func=find_resource)
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="3.0.0",
+    version="3.1.0",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",


### PR DESCRIPTION
When user passes `-s` or `--short` to `conduce-api find` a shortened list will returned with one line per resource.  

Hmm, maybe the option should be `--one-line` and `-1`.