### PR TITLE
Write tempfile in text mode

### DIFF
--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -179,7 +179,7 @@ def edit_resource(args):
 
     for resource in resources:
         EDITOR = os.environ.get('EDITOR', 'vim')
-        with tempfile.NamedTemporaryFile(suffix='.tmp') as resource_file:
+        with tempfile.NamedTemporaryFile(suffix='.tmp', mode='wt') as resource_file:
             resource_file.write(str(resource['content']))
             resource_file.flush()
             call([EDITOR, resource_file.name])


### PR DESCRIPTION
edit command was failing because it was trying to write a string to a binary file.  This change updates the file mode to text to get the command working again.