### PR TITLE
don't crash on unnamed resources

### DIFF
--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -143,7 +143,7 @@ def find_resource(args):
                     resource['content'] = base64.b64decode(resource['content'])
 
     if args.one_line:
-        return list(map((lambda x: "{}: {}".format(x['name'], x['id'])), resources))
+        return list(map((lambda x: "{}: {}".format(x.get('name', ''), x.get('id'))), resources))
 
     return resources
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="3.2.0",
+    version="3.2.1",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",


### PR DESCRIPTION
print empty string when no name exists and "None" when no ID exists (impossible).