### PR TITLE
util cleanup

### DIFF
--- a/conduce/api.py
+++ b/conduce/api.py
@@ -374,6 +374,7 @@ def set_generic_data(dataset_id, key, data_string, **kwargs):
     return ingest_samples(dataset_id, [entity], **kwargs)
 
 
+@_deprecated
 def _convert_coordinates(point):
     if len(point) != 2:
         raise KeyError('A point should only have two dimensions', point)
@@ -395,6 +396,7 @@ def _convert_coordinates(point):
     return coord
 
 
+@_deprecated
 def _convert_geometries(sample):
     coordinates = []
     if 'point' in sample:
@@ -417,6 +419,7 @@ def _convert_geometries(sample):
     return coordinates
 
 
+@_deprecated
 def _convert_samples_to_entity_set(sample_list):
     conduce_keys = ['id', 'kind', 'time', 'point', 'path', 'polygon']
     entities = []

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -495,6 +495,7 @@ def ingest_samples(dataset_id, sample_list, **kwargs):
     return _ingest_entity_set(dataset_id, entity_set, **kwargs)
 
 
+@_deprecated
 def convert_entities_to_entity_set(entity_list):
     conduce_keys = ['id', 'kind', 'point', 'path', 'polygon']
     entities = []
@@ -576,7 +577,7 @@ def ingest_entities(dataset_id, entity_list, **kwargs):
         Requests that result in an error raise an exception with information about the failure. See :py:meth:`requests.Response.raise_for_status` for more information.
     """
 
-    entity_set = convert_entities_to_entity_set(entity_list)
+    entity_set = util.entities_to_entity_set(entity_list)
 
     return _ingest_entity_set(dataset_id, entity_set, **kwargs)
 

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -491,7 +491,7 @@ def ingest_samples(dataset_id, sample_list, **kwargs):
     if not isinstance(sample_list, list):
         raise ValueError('sample_list must be a list', sample_list)
 
-    entity_set = _convert_samples_to_entity_set(sample_list)
+    entity_set = util.samples_to_entity_set(sample_list)
     return _ingest_entity_set(dataset_id, entity_set, **kwargs)
 
 

--- a/conduce/ingest.py
+++ b/conduce/ingest.py
@@ -1,3 +1,5 @@
+import json
+
 from . import api
 from . import util
 

--- a/conduce/util.py
+++ b/conduce/util.py
@@ -375,7 +375,7 @@ def csv_to_entities(infile, **kwargs):
 
 def _convert_coordinates(point):
     if len(point) != 2:
-        raise KeyError('A point should only have two dimensions', point)
+        raise KeyError('A point should only have two dimensions.', point)
     if 'lat' and 'lon' in point:
         coord = {
             'x': float(point['lon']),
@@ -387,7 +387,7 @@ def _convert_coordinates(point):
             'y': float(point['y'])
         }
     else:
-        raise KeyError('invalid coordinate', point)
+        raise KeyError('Invalid coordinate.', point)
 
     coord['z'] = 0
 
@@ -400,16 +400,16 @@ def _convert_geometries(sample):
         coordinates = [_convert_coordinates(sample['point'])]
     if 'path' in sample:
         if len(coordinates) > 0:
-            raise KeyError('A sample may only contain one of point, path or polygon', sample)
+            raise KeyError('A sample may only contain one of point, path or polygon.', sample)
         if len(sample['path']) < 2:
-            raise KeyError('paths must have at least two points')
+            raise KeyError('Paths must have at least two points.')
         for point in sample['path']:
             coordinates.append(_convert_coordinates(point))
     if 'polygon' in sample:
         if len(coordinates) > 0:
-            raise KeyError('A sample may only contain one of point, path or polygon', sample)
+            raise KeyError('A sample may only contain one of point, path or polygon.', sample)
         if len(sample['polygon']) < 3:
-            raise KeyError('polygons must have at least three points')
+            raise KeyError('Polygons must have at least three points.')
         for point in sample['polygon']:
             coordinates.append(_convert_coordinates(point))
 
@@ -439,7 +439,7 @@ def samples_to_entity_set(sample_list):
 
         coordinates = _convert_geometries(sample)
         if coordinates == []:
-            raise ValueError('Error processing sample at index {}.  Samples must define a location (point, path, or polygon)'.format(idx), sample)
+            raise ValueError('Error processing sample at index {}. Samples must define a location (point, path, or polygon).'.format(idx), sample)
 
         sample['_kind'] = sample['kind']
         attribute_keys = [key for key in list(sample.keys()) if key not in conduce_keys]

--- a/conduce/util.py
+++ b/conduce/util.py
@@ -504,9 +504,9 @@ def parse_samples(samples):
     return samples
 
 
-def json_to_samples(json_file):
-
-    return json.load(parse_samples, open(json_file))
+def json_to_samples(json_path):
+    with open(json_path, 'r') as json_file:
+        return json.load(parse_samples, open(json_file))
 
 
 if __name__ == '__main__':

--- a/doc/source/conduce-entities.rst
+++ b/doc/source/conduce-entities.rst
@@ -102,7 +102,7 @@ A source data record maps to a sample as follows::
     {
         "id": <ID>,
         "kind": <Method>,
-        "time": <Date> (converted to a datetime object)
+        "time": <Date> (converted to a datetime object),
         "point": {
             "lat": <Longitude>,
             "lon": <Latitude>
@@ -135,7 +135,7 @@ Ingesting entities
 
 In order to ingest our source data we must first convert each record into an entity sample as described above.  Once converted, the samples are added to a list.  The list may contain samples for multiple entities.  Once we have created our sample list we call :py:func:`api.ingest_samples`::
 
-    conduce.api.ingest_samples(dataset_id, 
+    conduce.api.ingest_samples(dataset_id,
         sample_list, host='app.conduce.com',
         api-key='00000000-0000-0000-0000-000000000000')
 
@@ -174,5 +174,5 @@ Particulars
 
 + The **kind** of an entity may change.
 + Conduce will not allow an entity to exist in two different states at the same time.  That is to say that two samples describing the same entity cannot have the same timestamp.
-+ A dataset should contain only static or dynamic entities, not both  
++ A dataset should contain only static or dynamic entities, not both
 

--- a/doc/source/entity-sample-definitions.rst
+++ b/doc/source/entity-sample-definitions.rst
@@ -39,7 +39,7 @@ A point sample defines an entity as a point in space.  Point samples are best us
     {
         "id": 1,
         "kind": "ball",
-        "time": datetime.datetime.now()
+        "time": datetime.datetime.now(),
         "point": {
             "x": 571045,
             "y": 22131
@@ -55,7 +55,7 @@ A geopoint sample defines an entity at a point in space.  Coordinates are define
     {
         "id": 1,
         "kind": "truck",
-        "time": datetime.datetime.now()
+        "time": datetime.datetime.now(),
         "point": {
             "lon": -91.571045,
             "lat": 38.022131
@@ -67,7 +67,7 @@ A geographic sample may also be represented in x,y (x = longitude, y = latitude)
     {
         "id": 1,
         "kind": "truck",
-        "time": datetime.datetime.now()
+        "time": datetime.datetime.now(),
         "point": {
             "x": -91.571045,
             "y": 38.022131
@@ -86,7 +86,7 @@ A path sample describes a connected sequence of points.  A path requires at leas
     {
         "id": 1,
         "kind": "trace",
-        "time": datetime.datetime.now()
+        "time": datetime.datetime.now(),
         "path": [{
             "x": 571045,
             "y": 22131
@@ -108,7 +108,7 @@ A geographic path sample describes a connected sequence of points in geographic 
     {
         "id": 1,
         "kind": "road",
-        "time": datetime.datetime.now()
+        "time": datetime.datetime.now(),
         "path": [{
             "lon": -91.571045,
             "lat": 38.022131
@@ -131,7 +131,7 @@ A polygon sample describes a closed sequence of points.  A polygon requires at l
     {
         "id": 1,
         "kind": "trace",
-        "time": datetime.datetime.now()
+        "time": datetime.datetime.now(),
         "polygon": [{
             "x": 571045,
             "y": 22131
@@ -156,7 +156,7 @@ A geographic polygon sample describes a closed sequence of points in geographic 
     {
         "id": 1,
         "kind": "road",
-        "time": datetime.datetime.now()
+        "time": datetime.datetime.now(),
         "polygon": [{
             "lon": -91.571045,
             "lat": 38.022131
@@ -186,7 +186,7 @@ Attributes are used to define characteristics of entities not encompassed by the
         "point": {
             "x": 571045,
             "y": 22131
-        }
+        },
         "color": "red",
         "size": 5,
         "velocity": 12.4,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="3.4.1",
+    version="3.4.0",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), "r") as f
 
 setup(
     name="conduce",
-    version="3.3.1",
+    version="3.4.1",
     description="Conduce Python API",
     author="Conduce",
     author_email="support@conduce.com",

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,343 @@
+import unittest
+import mock
+
+from conduce import util
+import datetime
+
+
+GOOD_POINT_SAMPLE = {
+    'id': 'fake ID',
+    'kind': 'fake kind',
+    'time': datetime.datetime.today(),
+    'point': 'fake point'
+}
+
+
+class ResultMock:
+    content = "{\"apikey\": \"fake json content\"}"
+
+
+class CustomHTTPException:
+    return_value = 409
+    msg = "Not found"
+
+
+class Test(unittest.TestCase):
+    def test__convert_coordinates__length_not_two(self):
+        fake_point = {
+            "x": 1,
+            "y": 2,
+            "z": 0
+        }
+        with self.assertRaisesRegex(KeyError, 'A point should only have two dimensions.'):
+            util._convert_coordinates(fake_point)
+
+    def test__convert_coordinates__unrecognized_keys(self):
+        fake_point = {
+            "a": 1,
+            "b": 2,
+        }
+        with self.assertRaisesRegex(KeyError, 'Invalid coordinate.'):
+            util._convert_coordinates(fake_point)
+
+    def test__convert_coordinates_xy(self):
+        fake_point = {
+            "x": 1,
+            "y": 2
+        }
+        expected_point = {
+            "x": 1,
+            "y": 2,
+            "z": 0
+        }
+        self.assertEqual(util._convert_coordinates(fake_point), expected_point)
+
+    def test__convert_coordinates_latlon(self):
+        fake_point = {
+            "lon": 1,
+            "lat": 2
+        }
+        expected_point = {
+            "x": 1,
+            "y": 2,
+            "z": 0
+        }
+        self.assertEqual(util._convert_coordinates(fake_point), expected_point)
+
+    def test__convert_geometries__no_location_returns_empty_list(self):
+        self.assertEqual(util._convert_geometries({}), [])
+
+    @mock.patch('conduce.util._convert_coordinates', return_value='path coordinates')
+    def test__convert_geometries__invalid_point_and_path(self, mock_convert_coordinates):
+        fake_path_sample = {
+            "id": 1,
+            "kind": "fake",
+            "time": datetime.datetime.now(),
+            "point": 'invalid point definition',
+            "path": [{
+                "x": 1,
+                "y": 2
+            }, {
+                "x": 3,
+                "y": 4
+            }, {
+                "x": 5,
+                "y": 6
+            }]
+        }
+
+        with self.assertRaisesRegex(KeyError, 'A sample may only contain one of point, path or polygon.'):
+            util._convert_geometries(fake_path_sample)
+
+    @mock.patch('conduce.util._convert_coordinates', return_value='path coordinates')
+    def test__convert_geometries__invalid_point_and_polygon(self, mock_convert_coordinates):
+        fake_path_sample = {
+            "id": 1,
+            "kind": "fake",
+            "time": datetime.datetime.now(),
+            "point": 'invalid point definition',
+            "polygon": [{
+                "x": 1,
+                "y": 2
+            }, {
+                "x": 3,
+                "y": 4
+            }, {
+                "x": 5,
+                "y": 6
+            }]
+        }
+
+        with self.assertRaisesRegex(KeyError, 'A sample may only contain one of point, path or polygon.'):
+            util._convert_geometries(fake_path_sample)
+
+    @mock.patch('conduce.util._convert_coordinates', return_value='path coordinates')
+    def test__convert_geometries__invalid_path_and_polygon(self, mock_convert_coordinates):
+        fake_path_sample = {
+            "id": 1,
+            "kind": "fake",
+            "time": datetime.datetime.now(),
+            "polygon": 'invalid polygon definition',
+            "path": [{
+                "x": 1,
+                "y": 2
+            }, {
+                "x": 3,
+                "y": 4
+            }, {
+                "x": 5,
+                "y": 6
+            }]
+        }
+
+        with self.assertRaisesRegex(KeyError, 'A sample may only contain one of point, path or polygon.'):
+            util._convert_geometries(fake_path_sample)
+
+    @mock.patch('conduce.util._convert_coordinates', return_value='point coordinates')
+    def test__convert_geometries__point_location(self, mock_convert_coordinates):
+        self.assertEqual(util._convert_geometries({'point': 'fake point'}), ['point coordinates'])
+        mock_convert_coordinates.assert_called_once_with('fake point')
+
+    @mock.patch('conduce.util._convert_coordinates', return_value='path coordinates')
+    def test__convert_geometries__path_too_short(self, mock_convert_coordinates):
+        fake_path_sample = {
+            "id": 1,
+            "kind": "fake",
+            "time": datetime.datetime.now(),
+            "path": [{
+                "x": 1,
+                "y": 2
+            }]
+        }
+        with self.assertRaisesRegex(KeyError, 'Paths must have at least two points.'):
+            util._convert_geometries(fake_path_sample)
+
+    @mock.patch('conduce.util._convert_coordinates', return_value='path coordinates')
+    def test__convert_geometries__path_location(self, mock_convert_coordinates):
+        fake_path_sample = {
+            "id": 1,
+            "kind": "fake",
+            "time": datetime.datetime.now(),
+            "path": [{
+                "x": 1,
+                "y": 2
+            }, {
+                "x": 3,
+                "y": 4
+            }, {
+                "x": 5,
+                "y": 6
+            }]
+        }
+        self.assertEqual(util._convert_geometries(fake_path_sample), ['path coordinates', 'path coordinates', 'path coordinates'])
+        self.assertEqual(len(mock_convert_coordinates.call_args_list), 3)
+        for idx, call_args in enumerate(mock_convert_coordinates.call_args_list):
+            self.assertEqual(call_args, mock.call(fake_path_sample['path'][idx]))
+
+    @mock.patch('conduce.util._convert_coordinates', return_value='polygon coordinates')
+    def test__convert_geometries__polygon_too_short(self, mock_convert_coordinates):
+        fake_polygon_sample = {
+            "id": 1,
+            "kind": "fake",
+            "time": datetime.datetime.now(),
+            "polygon": [{
+                "x": 1,
+                "y": 2
+            }]
+        }
+        with self.assertRaisesRegex(KeyError, 'Polygons must have at least three points.'):
+            util._convert_geometries(fake_polygon_sample)
+
+    @mock.patch('conduce.util._convert_coordinates', return_value='polygon coordinates')
+    def test__convert_geometries__polygon_location(self, mock_convert_coordinates):
+        fake_polygon_sample = {
+            "id": 1,
+            "kind": "fake",
+            "time": datetime.datetime.now(),
+            "polygon": [{
+                "x": 1,
+                "y": 2
+            }, {
+                "x": 3,
+                "y": 4
+            }, {
+                "x": 5,
+                "y": 6
+            }]
+        }
+        self.assertEqual(util._convert_geometries(fake_polygon_sample), ['polygon coordinates', 'polygon coordinates', 'polygon coordinates'])
+        self.assertEqual(len(mock_convert_coordinates.call_args_list), 3)
+        for idx, call_args in enumerate(mock_convert_coordinates.call_args_list):
+            self.assertEqual(call_args, mock.call(fake_polygon_sample['polygon'][idx]))
+
+    def test_samples_to_entity_set__no_id(self):
+        NO_ID_SAMPLE = {
+            'kind': 'fake kind',
+            'time': datetime.datetime.today(),
+            'point': 'fake point'
+        }
+
+        fake_sample_list = [NO_ID_SAMPLE]
+        with self.assertRaisesRegex(ValueError, 'Error processing sample at index 0. Samples must include an ID.'):
+            util.samples_to_entity_set(fake_sample_list)
+
+    def test_samples_to_entity_set__no_kind(self):
+        NO_ID_SAMPLE = {
+            'id': 'fake ID',
+            'time': datetime.datetime.today(),
+            'point': 'fake point'
+        }
+
+        fake_sample_list = [NO_ID_SAMPLE]
+        with self.assertRaisesRegex(ValueError, 'Error processing sample at index 0. Samples must include a kind field.'):
+            util.samples_to_entity_set(fake_sample_list)
+
+    def test_samples_to_entity_set__no_time(self):
+        NO_ID_SAMPLE = {
+            'id': 'fake ID',
+            'kind': 'fake kind',
+            'point': 'fake point'
+        }
+
+        fake_sample_list = [NO_ID_SAMPLE]
+        with self.assertRaisesRegex(ValueError, 'Error processing sample at index 0. Samples must include a time field.'):
+            util.samples_to_entity_set(fake_sample_list)
+
+    def test_samples_to_entity_set__invalid_id(self):
+        NO_ID_SAMPLE = {
+            'id': '',
+            'kind': 'fake kind',
+            'time': datetime.datetime.today(),
+            'point': 'fake point'
+        }
+
+        fake_sample_list = [NO_ID_SAMPLE]
+        with self.assertRaisesRegex(ValueError, 'Error processing sample at index 0. Invalid ID.'):
+            util.samples_to_entity_set(fake_sample_list)
+
+    def test_samples_to_entity_set__invalid_kind(self):
+        NO_ID_SAMPLE = {
+            'id': 'fake ID',
+            'kind': '',
+            'time': datetime.datetime.today(),
+            'point': 'fake point'
+        }
+
+        fake_sample_list = [NO_ID_SAMPLE]
+        with self.assertRaisesRegex(ValueError, 'Error processing sample at index 0. Invalid kind.'):
+            util.samples_to_entity_set(fake_sample_list)
+
+    def test_samples_to_entity_set__invalid_time(self):
+        NO_ID_SAMPLE = {
+            'id': 'fake ID',
+            'kind': 'fake kind',
+            'point': 'fake point',
+            'time': None
+        }
+
+        fake_sample_list = [NO_ID_SAMPLE]
+        with self.assertRaisesRegex(ValueError, 'Error processing sample at index 0. Invalid time.'):
+            util.samples_to_entity_set(fake_sample_list)
+
+    def test_samples_to_entity_set__time_not_datetime(self):
+        NO_ID_SAMPLE = {
+            'id': 'fake ID',
+            'kind': 'fake kind',
+            'point': 'fake point',
+            'time': 'invalid time',
+        }
+
+        fake_sample_list = [NO_ID_SAMPLE]
+        with self.assertRaisesRegex(TypeError, 'Error processing sample at index 0. Time must be a datetime object.'):
+            util.samples_to_entity_set(fake_sample_list)
+
+    @mock.patch('conduce.util._convert_geometries', return_value=[])
+    def test_samples_to_entity_set__invalid_location(self, mock_convert_geometries):
+
+        fake_sample_list = [GOOD_POINT_SAMPLE]
+        with self.assertRaisesRegex(ValueError, 'Error processing sample at index 0. Samples must define a location \(point, path, or polygon\).'):
+            util.samples_to_entity_set(fake_sample_list)
+
+    @mock.patch('conduce.util.datetime_to_timestamp_ms', return_value="fake sample time")
+    @mock.patch('conduce.util.get_attributes', return_value="fake attributes")
+    @mock.patch('conduce.util._convert_geometries', return_value="fake converted geometries")
+    def test_samples_to_entity_set(self, mock_convert_geometries, mock_get_attributes, mock_datetime_to_timestamp):
+
+        fake_sample_list = [GOOD_POINT_SAMPLE]
+        expected_entity_set = {'entities': [{
+            'identity': GOOD_POINT_SAMPLE['id'],
+            'kind': GOOD_POINT_SAMPLE['kind'],
+            'timestamp_ms': 'fake sample time',
+            'endtime_ms': 'fake sample time',
+            'path': 'fake converted geometries',
+            'attrs': 'fake attributes',
+        }]}
+        self.assertEqual(util.samples_to_entity_set(fake_sample_list), expected_entity_set)
+        mock_convert_geometries.assert_called_once_with(GOOD_POINT_SAMPLE)
+        mock_get_attributes.assert_called_once_with(['_kind'], GOOD_POINT_SAMPLE)
+        mock_datetime_to_timestamp.assert_called_with(GOOD_POINT_SAMPLE['time'])
+        self.assertEqual(len(mock_datetime_to_timestamp.call_args_list), 2)
+
+    @mock.patch('dateutil.parser.parse', return_value="fake datetime object")
+    def test_parse_samples(self, mock_dateutil_parser_parse):
+        fake_json_samples = [{'id': 'fake ID 1', 'time': 'fake time string'}, {'id': 'fake ID 2'}]
+        fake_parsed_samples = [{'id': 'fake ID 1', 'time': 'fake datetime object'}, {'id': 'fake ID 2'}]
+
+        self.assertEqual(util.parse_samples(fake_json_samples), fake_parsed_samples)
+
+        mock_dateutil_parser_parse.assert_called_once_with('fake time string')
+
+    @mock.patch('builtins.open', return_value="fake file stream")
+    @mock.patch('json.load', return_value="fake JSON")
+    @mock.patch('conduce.util.parse_samples', return_value="deserialized samples")
+    def test_json_to_samples(self, mock_parse_samples, mock_json_load, mock_open):
+        fake_file = "fake file path"
+
+        self.assertEqual(util.json_to_samples(fake_file), 'fake JSON')
+
+        mock_json_load.assert_called_once_with(
+            mock_parse_samples, "fake file stream")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change moves some utility functions out of api.py.  These functions convert samples (as defined in the documentation) to entity sets.  They are valuable outside the api package.

EDIT:  I also threw in a documentation fix for some syntax error in examples.