### PR TITLE
SKW-4167: post transaction methods and cli

### DIFF
--- a/conduce/api.py
+++ b/conduce/api.py
@@ -626,6 +626,7 @@ def _post_transaction(dataset_id, entity_set, **kwargs):
     should be avoided in favor of :py:func:`insert_transaction` and :py:func:`append_transaction`.
 
     By default, the transaction will not be processed. Use the \`process\` kwarg to trigger automatic processing.
+
     Parameters
     ----------
     dataset_id : string

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -622,7 +622,7 @@ def append_transaction(dataset_id, entity_set, **kwargs):
 
 def _post_transaction(dataset_id, entity_set, **kwargs):
     if 'entities' not in entity_set:
-        raise ValueError('parameter entity_set is not an \'entities\' dict')
+        raise ValueError("Parameter entity_set is not an 'entities' dict.")
 
     if kwargs.get('debug'):
         kwargs['debug'] = False
@@ -640,7 +640,7 @@ def _post_transaction(dataset_id, entity_set, **kwargs):
         'op': kwargs.get('operation', 'INSERT'),
     }
     response = make_post_request(
-        payload, '/api/v2/data/{}/transactions?process={}'.format(dataset_id, kwargs.get('process', False)), **kwargs)
+        payload, '/api/v2/data/{}/transactions?process={}'.format(dataset_id, bool(kwargs.get('process', False))), **kwargs)
     response.raise_for_status()
 
     if kwargs.get('process', False):

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -639,14 +639,8 @@ def _post_transaction(dataset_id, entity_set, **kwargs):
         'data': entity_set,
         'op': kwargs.get('operation', 'INSERT'),
     }
-    response = None
-    if kwargs.get('process', False):
-        response = make_post_request(
-            payload, '/api/v2/data/{}/transactions?process={}'.format(dataset_id, kwargs.get('process', False)), **kwargs)
-    else:
-        # HACK: This works around a bug in the REST API. Remove when the process parameter is handled correctly
-        response = make_post_request(
-            payload, '/api/v2/data/{}/transactions'.format(dataset_id), **kwargs)
+    response = make_post_request(
+        payload, '/api/v2/data/{}/transactions?process={}'.format(dataset_id, kwargs.get('process', False)), **kwargs)
     response.raise_for_status()
 
     if kwargs.get('process', False):

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -606,26 +606,27 @@ def insert_transaction(dataset_id, entity_set, **kwargs):
 
     The operation will fail if the records are not unique.  Uniqueness is determined by the combination of a record's ID and timestamp.
     """
-    return _post_transaction(dataset_id, entity_set, operation='INSERT', **kwargs)
+    return post_transaction(dataset_id, entity_set, operation='INSERT', **kwargs)
 
 
 def append_transaction(dataset_id, entity_set, **kwargs):
     """
     Add new records to the end of the dataset.
 
-    Append is an optimization over insert in that it only checks to see that all records in the transaction are newer than the newest record in the transaction log.
+    Append is an optimization over insert in that it only checks to see that all records in the transaction
+    are newer than the newest record in the transaction log.
 
     Append may fail to add valid records that occur between the end of an entity stream and the end of a dataset.
     """
-    return _post_transaction(dataset_id, entity_set, operation='APPEND', **kwargs)
+    return post_transaction(dataset_id, entity_set, operation='APPEND', **kwargs)
 
 
-def _post_transaction(dataset_id, entity_set, **kwargs):
+def post_transaction(dataset_id, entity_set, **kwargs):
     """
     Add a new dataset transaction.  This method is provided for completeness and
     should be avoided in favor of :py:func:`insert_transaction` and :py:func:`append_transaction`.
 
-    By default, the transaction will not be processed. Use the \`process\` kwarg to trigger automatic processing.
+    By default, the transaction will not be processed. Use the `process` kwarg to trigger automatic processing.
 
     Parameters
     ----------
@@ -638,14 +639,14 @@ def _post_transaction(dataset_id, entity_set, **kwargs):
     **kwargs : key-value
         **operation**
             The dataset operation to perform on the posted entity set.  Supports all
-            operations listed in the REST API.  However, only \`INSERT`\ and \`APPEND\` are officially supported.
+            operations listed in the REST API.  However, only `INSERT` and `APPEND` are officially supported.
             See https://prd-docs.conduce.com/#/data/createTransaction for a list of endpoints.
         **process**
             Post the transaction and immediately process on backends configured to automatically process transactions.
         **debug**
             Post each entity in the entity set as an individual transaction.
             This enables a user to find bad entities in an entity set but dramatically slows data processing.
-            Forces \`process=True\` to ensure entities are ingested one at a time.
+            Forces `process=True` to ensure entities are ingested one at a time.
 
         See :py:func:`make_post_request` for more kwargs.
 
@@ -665,7 +666,7 @@ def _post_transaction(dataset_id, entity_set, **kwargs):
         for idx, entity in enumerate(entity_set['entities'], start=1):
             single_entity = {'entities': [entity]}
             print(single_entity)
-            responses.append(_post_transaction(dataset_id, single_entity, **kwargs))
+            responses.append(post_transaction(dataset_id, single_entity, **kwargs))
             print("{} / {} ingested".format(idx, len(entity_set['entities'])))
         return responses
 

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -621,6 +621,38 @@ def append_transaction(dataset_id, entity_set, **kwargs):
 
 
 def _post_transaction(dataset_id, entity_set, **kwargs):
+    """
+    Add a new dataset transaction.  This method is provided for completeness and
+    should be avoided in favor of :py:func:`insert_transaction` and :py:func:`append_transaction`.
+
+    By default, the transaction will not be processed. Use the \`process\` kwarg to trigger automatic processing.
+    Parameters
+    ----------
+    dataset_id : string
+        The UUID that identifies the dataset to modify.
+    entity_set : dictionary
+        A dictionary of raw Conduce entities. Use :py:meth:`util.samples_to_entity_set` or
+        :py:meth:`util.entities_to_entity_set` to construct an entity set dictionary.
+        See :doc:`data-ingest` for documentation on how to ingest data.
+    **kwargs : key-value
+        **operation**
+            The dataset operation to perform on the posted entity set.  Supports all
+            operations listed in the REST API.  However, only \`INSERT`\ and \`APPEND\` are officially supported.
+            See https://prd-docs.conduce.com/#/data/createTransaction for a list of endpoints.
+        **process**
+            Post the transaction and immediately process on backends configured to automatically process transactions.
+        **debug**
+            Post each entity in the entity set as an individual transaction.
+            This enables a user to find bad entities in an entity set but dramatically slows data processing.
+            Forces \`process=True\` to ensure entities are ingested one at a time.
+
+        See :py:func:`make_post_request` for more kwargs.
+
+    Returns
+    -------
+    requests.Response
+        Returns an error or the final response message when the job is no longer running.
+    """
     if 'entities' not in entity_set:
         raise ValueError("Parameter entity_set is not an 'entities' dict.")
 

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -639,8 +639,14 @@ def _post_transaction(dataset_id, entity_set, **kwargs):
         'data': entity_set,
         'op': kwargs.get('operation', 'INSERT'),
     }
-    response = make_post_request(
-        payload, '/api/v2/data/{}/transactions?process={}'.format(dataset_id, kwargs.get('process', False)), **kwargs)
+    response = None
+    if kwargs.get('process', False):
+        response = make_post_request(
+            payload, '/api/v2/data/{}/transactions?process={}'.format(dataset_id, kwargs.get('process', False)), **kwargs)
+    else:
+        # HACK: This works around a bug in the REST API. Remove when the process parameter is handled correctly
+        response = make_post_request(
+            payload, '/api/v2/data/{}/transactions'.format(dataset_id), **kwargs)
     response.raise_for_status()
 
     if kwargs.get('process', False):

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -626,6 +626,7 @@ def _post_transaction(dataset_id, entity_set, **kwargs):
 
     if kwargs.get('debug'):
         kwargs['debug'] = False
+        kwargs['process'] = True
         print("Debug ingest")
         responses = []
         for idx, entity in enumerate(entity_set['entities'], start=1):

--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -9,7 +9,6 @@ import os
 import sys
 from subprocess import call
 import mimetypes
-from dateutil import parser
 
 from . import config
 from . import api

--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -680,7 +680,7 @@ def main():
     parser_config_get_api_key.add_argument('--host', help='The server on which the API key is valid')
     parser_config_get_api_key.set_defaults(func=config.get_api_key_config)
 
-    parser_config_list = subparsers.add_parser('list',  parents=[api_cmd_parser], help='List resources by type')
+    parser_config_list = subparsers.add_parser('list', parents=[api_cmd_parser], help='List resources by type')
     parser_config_list.add_argument('object_to_list', help='Conduce object to list')
 
     parser_config_list.set_defaults(func=list_from_args)

--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -282,14 +282,11 @@ def create_dataset(args):
 def read_entity_set_from_samples_file(args):
     sample_list = None
     if args.csv:
-        sample_list = util.csv_to_json(args.csv)
+        sample_list = util.parse_samples(util.csv_to_json(args.csv))
     if args.json:
-        sample_list = json.load(open(args.json))
+        sample_list = util.json_to_samples(args.json)
 
-    for sample in sample_list:
-        sample['time'] = parser.parse(sample['time'])
-
-    return api._convert_samples_to_entity_set(sample_list)
+    return util.samples_to_entity_set(sample_list)
 
 
 def append_transaction(args):

--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -278,6 +278,27 @@ def create_dataset(args):
     return response
 
 
+def insert_transaction(args):
+    from dateutil import parser
+    sample_list = None
+    if args.csv:
+        sample_list = util.csv_to_json(args.csv)
+    if args.json:
+        sample_list = json.load(open(args.json))
+
+    for sample in sample_list:
+        sample['time'] = parser.parse(sample['time'])
+
+    entity_set = api._convert_samples_to_entity_set(sample_list)
+    dataset_id = args.dataset_id
+    del vars(args)['dataset_id']
+
+    response = api.insert_transaction(dataset_id, entity_set, **vars(args))
+    print(response.headers)
+    print(response.status_code)
+    return response
+
+
 def ingest_data(args):
     if args.raw:
         del vars(args)['dataset_id']
@@ -652,7 +673,7 @@ def main():
 
     parser_config_list.set_defaults(func=list_from_args)
 
-    parser_find = subparsers.add_parser('find',  parents=[api_cmd_parser], help='Find resources that match the given parameters')
+    parser_find = subparsers.add_parser('find', parents=[api_cmd_parser], help='Find resources that match the given parameters')
     parser_find.add_argument('--type', help='Conduce resource type to find')
     parser_find.add_argument('--name', help='The name of the resource to find')
     parser_find.add_argument('--id', help='The ID of the resource to find')
@@ -669,19 +690,39 @@ def main():
     parser_dataset_subparsers.required = True
 
     parser_dataset_get_metadata = parser_dataset_subparsers.add_parser(
-        'metadata',  parents=[api_cmd_parser], help='List dataset metadata for resources that match the given parameters')
+        'metadata', parents=[api_cmd_parser], help='List dataset metadata for resources that match the given parameters')
     parser_dataset_get_metadata.add_argument('--name', help='The name of the dataset to query')
     parser_dataset_get_metadata.add_argument('--id', help='The ID of the dataset to query')
     parser_dataset_get_metadata.add_argument('--regex', help='An expression to match datasets and query')
     parser_dataset_get_metadata.set_defaults(func=get_dataset_metadata)
 
-    parser_create_resource = subparsers.add_parser('create',  parents=[api_cmd_parser], help='Create a new resource')
+    dataset_post_transaction_parser = ConduceCommandLineParser(add_help=False)
+    dataset_post_transaction_parser.add_argument('--json', help='Optional: A JSON file that can parsed into Conduce entities')
+    dataset_post_transaction_parser.add_argument('--csv', help='Optional: A CSV file that can be parsed as Conduce data')
+    dataset_post_transaction_parser.add_argument(
+        '--raw', help='Optional: A well formatted Conduce entities JSON file. Ignores --kind, --generate-ids and --answer-yes')
+    dataset_post_transaction_parser.add_argument('--generate-ids', help='Set this flag if the data does not contain an ID field', action='store_true')
+    dataset_post_transaction_parser.add_argument('--kind', help='Use this value as the kind for all entities')
+    dataset_post_transaction_parser.add_argument('--answer-yes', help='Set this flag to answer yes at all prompts', action='store_true')
+    dataset_post_transaction_parser.add_argument('--debug', help='Get better information about errors', action='store_true')
+
+    parser_dataset_create = parser_dataset_subparsers.add_parser(
+        'create', parents=[api_cmd_parser, dataset_post_transaction_parser], help='Create a new dataset with optional data')
+    parser_dataset_create.add_argument('name', help='The name to be given to the new dataset')
+    parser_dataset_create.set_defaults(func=create_dataset)
+
+    parser_dataset_insert = parser_dataset_subparsers.add_parser(
+        'insert', parents=[api_cmd_parser, dataset_post_transaction_parser], help='Insert records into a dataset')
+    parser_dataset_insert.add_argument('dataset_id', help='Unique identifier of the dataset in which data will be inserted')
+    parser_dataset_insert.set_defaults(func=insert_transaction)
+
+    parser_create_resource = subparsers.add_parser('create', parents=[api_cmd_parser], help='Create a new resource')
     parser_create_resource.add_argument('name', help='The name of the resource to create')
     parser_create_resource.add_argument('type', help='Conduce resource type to create')
     parser_create_resource.add_argument('--content', help='The content of the new resource')
     parser_create_resource.set_defaults(func=create_resource)
 
-    parser_edit_resource = subparsers.add_parser('edit',  parents=[api_cmd_parser], help='Edit resources that match the given parameters')
+    parser_edit_resource = subparsers.add_parser('edit', parents=[api_cmd_parser], help='Edit resources that match the given parameters')
     parser_edit_resource.add_argument('--type', help='Conduce resource type to edit')
     parser_edit_resource.add_argument('--name', help='The name of the resource to edit')
     parser_edit_resource.add_argument('--id', help='The ID of the resource to edit')
@@ -698,7 +739,7 @@ def main():
     parser_rename_resource.add_argument('-v', '--verbose', action='store_true', help='Find and print metadata for resource after rename')
     parser_rename_resource.set_defaults(func=rename_resource)
 
-    parser_copy_resource = subparsers.add_parser('copy',  parents=[api_cmd_parser], help='Copy resource that matches the given parameters')
+    parser_copy_resource = subparsers.add_parser('copy', parents=[api_cmd_parser], help='Copy resource that matches the given parameters')
     parser_copy_resource.add_argument('resource_name', help='Name of newly copied resource')
     parser_copy_resource.add_argument('--type', help='Conduce resource type to copy')
     parser_copy_resource.add_argument('--name', help='The name of the resource to copy')
@@ -706,7 +747,7 @@ def main():
     parser_copy_resource.add_argument('--regex', help='An expression matching a single resource to copy')
     parser_copy_resource.set_defaults(func=copy_resource)
 
-    parser_edit_entity_entity = subparsers.add_parser('edit-entity',  parents=[api_cmd_parser], help='Edit a dataset entity that match the given parameters')
+    parser_edit_entity_entity = subparsers.add_parser('edit-entity', parents=[api_cmd_parser], help='Edit a dataset entity that match the given parameters')
     parser_edit_entity_entity.add_argument('--id', help='The ID of the entity to edit')
     parser_edit_entity_entity.add_argument('--dataset-id', help='The ID of the dataset that contains the entity')
     parser_edit_entity_entity.add_argument('--date', help='The date at which the entity occurred (optional, if not specified the newest will be selected.)')

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -28,7 +28,7 @@ class CustomHTTPException:
 
 
 class Test(unittest.TestCase):
-    @mock.patch('conduce.api._post_transaction', return_value=ResultMock())
+    @mock.patch('conduce.api.post_transaction', return_value=ResultMock())
     def test_append_transaction(self, mock_post_transaction):
         fake_id = 'fake id'
         fake_set = 'fake entities'
@@ -36,7 +36,7 @@ class Test(unittest.TestCase):
         api.append_transaction(fake_id, fake_set, **fake_kwargs)
         mock_post_transaction.assert_called_once_with(fake_id, fake_set, operation='APPEND', **fake_kwargs)
 
-    @mock.patch('conduce.api._post_transaction', return_value=ResultMock())
+    @mock.patch('conduce.api.post_transaction', return_value=ResultMock())
     def test_insert_transaction(self, mock_post_transaction):
         fake_id = 'fake id'
         fake_set = 'fake entities'
@@ -44,16 +44,16 @@ class Test(unittest.TestCase):
         api.insert_transaction(fake_id, fake_set, **fake_kwargs)
         mock_post_transaction.assert_called_once_with(fake_id, fake_set, operation='INSERT', **fake_kwargs)
 
-    def test__post_transaction__invalid_entity_set(self):
+    def test_post_transaction__invalid_entity_set(self):
         with self.assertRaisesRegex(ValueError, "Parameter entity_set is not an 'entities' dict."):
-            api._post_transaction('id', {'invalid_set': 'set'})
+            api.post_transaction('id', {'invalid_set': 'set'})
 
     @mock.patch('conduce.api.make_post_request', return_value=ResultMock_201())
-    def test__post_transaction__default_operation(self, mock_make_post_request):
+    def test_post_transaction__default_operation(self, mock_make_post_request):
         fake_id = 'fake_id'
         fake_entities = {'entities': 'fake entities'}
         fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
-        self.assertIsInstance(api._post_transaction(fake_id, fake_entities, **fake_kwargs), ResultMock_201)
+        self.assertIsInstance(api.post_transaction(fake_id, fake_entities, **fake_kwargs), ResultMock_201)
 
         expected_payload = {
             'data': fake_entities,
@@ -63,11 +63,11 @@ class Test(unittest.TestCase):
         mock_make_post_request.assert_called_once_with(expected_payload, expected_uri, **fake_kwargs)
 
     @mock.patch('conduce.api.make_post_request', return_value=ResultMock_201())
-    def test__post_transaction__process_true(self, mock_make_post_request):
+    def test_post_transaction__process_true(self, mock_make_post_request):
         fake_id = 'fake_id'
         fake_entities = {'entities': 'fake entities'}
         fake_kwargs = {'arg1': 'arg1', 'process': True}
-        self.assertIsInstance(api._post_transaction(fake_id, fake_entities, **fake_kwargs), ResultMock_201)
+        self.assertIsInstance(api.post_transaction(fake_id, fake_entities, **fake_kwargs), ResultMock_201)
 
         expected_payload = {
             'data': fake_entities,
@@ -77,11 +77,11 @@ class Test(unittest.TestCase):
         mock_make_post_request.assert_called_once_with(expected_payload, expected_uri, **fake_kwargs)
 
     @mock.patch('conduce.api.make_post_request', return_value=ResultMock_201())
-    def test__post_transaction__kwargs_operation(self, mock_make_post_request):
+    def test_post_transaction__kwargs_operation(self, mock_make_post_request):
         fake_id = 'fake_id'
         fake_entities = {'entities': 'fake entities'}
         fake_kwargs = {'arg1': 'arg1', 'operation': 'fake_op'}
-        self.assertIsInstance(api._post_transaction(fake_id, fake_entities, **fake_kwargs), ResultMock_201)
+        self.assertIsInstance(api.post_transaction(fake_id, fake_entities, **fake_kwargs), ResultMock_201)
 
         expected_payload = {
             'data': fake_entities,
@@ -91,12 +91,12 @@ class Test(unittest.TestCase):
         mock_make_post_request.assert_called_once_with(expected_payload, expected_uri, **fake_kwargs)
 
     @mock.patch('conduce.api.make_post_request', return_value=ResultMock_201())
-    def test__post_transaction__debug(self, mock_make_post_request):
+    def test_post_transaction__debug(self, mock_make_post_request):
         fake_id = 'fake_id'
         fake_entities = ['fake entity 1', 'fake entity 2', 'fake entity 3']
         fake_entity_set = {'entities': fake_entities}
         fake_kwargs = {'arg1': 'arg1', 'debug': True}
-        self.assertIsInstance(api._post_transaction(fake_id, fake_entity_set, **fake_kwargs), list)
+        self.assertIsInstance(api.post_transaction(fake_id, fake_entity_set, **fake_kwargs), list)
 
         expected_uri = '/api/v2/data/fake_id/transactions?process=True'
         for idx, call_args in enumerate(mock_make_post_request.call_args_list):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -90,6 +90,24 @@ class Test(unittest.TestCase):
         expected_uri = '/api/v2/data/fake_id/transactions?process=False'
         mock_make_post_request.assert_called_once_with(expected_payload, expected_uri, **fake_kwargs)
 
+    @mock.patch('conduce.api.make_post_request', return_value=ResultMock_201())
+    def test__post_transaction__debug(self, mock_make_post_request):
+        fake_id = 'fake_id'
+        fake_entities = ['fake entity 1', 'fake entity 2', 'fake entity 3']
+        fake_entity_set = {'entities': fake_entities}
+        fake_kwargs = {'arg1': 'arg1', 'debug': True}
+        self.assertIsInstance(api._post_transaction(fake_id, fake_entity_set, **fake_kwargs), list)
+
+        expected_uri = '/api/v2/data/fake_id/transactions?process=True'
+        for idx, call_args in enumerate(mock_make_post_request.call_args_list):
+            expected_payload = {
+                'data': {'entities': [fake_entities[idx]]},
+                'op': 'INSERT'
+            }
+            fake_kwargs = {'arg1': 'arg1', 'debug': False, 'process': True}
+            self.assertEqual(call_args, mock.call(expected_payload, expected_uri, **fake_kwargs))
+            expected_uri = '/api/v2/data/fake_id/transactions?process=True'
+
     @mock.patch('conduce.api.make_post_request', return_value=ResultMock())
     def test_create_resource_mime_type_json(self, mock_make_post_request):
         test_resource_type = "test_resource_type"

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -4,6 +4,13 @@ import mock
 from conduce import util
 import datetime
 
+# Python 2 compatibility
+try:
+    import __builtin__ as builtins
+except:
+    import builtins
+assert(hasattr(builtins, 'open'))
+###
 
 GOOD_POINT_ENTITY = {
     'id': 'fake ID',
@@ -28,6 +35,11 @@ class CustomHTTPException:
 
 
 class Test(unittest.TestCase):
+    # For Python 2 compatibility
+    if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
+        unittest.TestCase.assertRaisesRegex = unittest.TestCase.assertRaisesRegexp
+    ###
+
     def test__convert_coordinates__length_not_two(self):
         fake_point = {
             "x": 1,
@@ -422,7 +434,7 @@ class Test(unittest.TestCase):
         for idx, call_args in enumerate(mock_parse_sample.call_args_list):
             self.assertEqual(call_args, mock.call(fake_json_samples[idx]))
 
-    @mock.patch('builtins.open', return_value="fake file stream")
+    @mock.patch.object(builtins, 'open', return_value="fake file stream")
     @mock.patch('json.load', return_value="fake JSON")
     @mock.patch('conduce.util.parse_sample', return_value="deserialized samples")
     def test_json_to_samples(self, mock_parse_sample, mock_json_load, mock_open):


### PR DESCRIPTION
This change adds post transaction methods to the Python API.

Updates documentation and tests.

Fixes bad code in json_to_samples.

Not changing the version number until all API methods have been updated. (Let me know if that's a bad idea.)