### PR TITLE
SKW-4167: delete transactions

### DIFF
--- a/conduce/api.py
+++ b/conduce/api.py
@@ -737,6 +737,25 @@ def get_transactions(dataset_id, **kwargs):
     return make_get_request(fragment, parameters=parameters, **kwargs)
 
 
+def delete_transactions(dataset_id, **kwargs):
+    """
+    Clear all dataset transactions from Conduce.
+    Delete and re-create dataset backends.
+
+    Return the dataset and all backends to an intialized (empty) state.
+    Dataset is ready for ingest when request is finished.
+
+    Returns
+    -------
+    requests.Response
+         On success, an asynchronous job ID.  Check the job status for deletion progress.
+         (See :py:func:`wait_for_job`)
+    """
+
+    fragment = '/api/v2/data/{}/transactions'.format(dataset_id)
+    return make_delete_request(fragment, **kwargs)
+
+
 def _ingest_entity_set(dataset_id, entity_set, **kwargs):
     if 'entities' not in entity_set:
         raise ValueError('parameter entity_set is not an \'entities\' dict')

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -28,6 +28,14 @@ class CustomHTTPException:
 
 
 class Test(unittest.TestCase):
+    @mock.patch('conduce.api.make_delete_request', return_value=ResultMock())
+    def test_delete_transactions(self, mock_make_get_request):
+        fake_id = 'fake-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        expected_uri = '/api/v2/data/{}/transactions'.format(fake_id)
+        api.delete_transactions(fake_id, **fake_kwargs)
+        mock_make_get_request.assert_called_once_with(expected_uri, **fake_kwargs)
+
     @mock.patch('conduce.api.make_get_request', return_value=ResultMock())
     def test_get_transactions(self, mock_make_get_request):
         fake_id = 'fake-id'


### PR DESCRIPTION
Adds API for delete_transactions.  Does not change the CLI.  CLI will be updated when high level `clear_dataset` is modified to call `delete_transactions`.