### PR TITLE
SKW-4168: create dataset backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+deps: setup-env deps-venv2 deps-venv3
+
+setup-env: venv2 venv3 
+
+venv2:
+	mkdir -p venv2
+	cd venv2
+	pyenv install -s 2.7.16
+	pyenv local 2.7.16
+	cd ..
+	virtualenv venv2
+
+venv3:
+	mkdir -p venv3
+	cd venv3
+	pyenv install -s 3.7.4
+	pyenv local 3.7.4
+	cd ..
+	python -m venv venv3 
+
+deps-venv2: venv2 requirements-dev.txt
+	./venv2/bin/pip install -r requirements-dev.txt
+
+deps-venv3: venv3 requirements-dev.txt
+	./venv3/bin/pip install --upgrade pip
+	./venv3/bin/pip install -r requirements-dev.txt
+
+test: clean-pyc test2 test3
+
+test2:
+	./venv2/bin/python -m unittest discover -v test/
+
+test3:
+	./venv3/bin/python -m unittest discover -v test/
+
+docs: venv3 
+	. ./venv3/bin/activate && make -C doc html
+
+clean-pyc:
+	find . -name '*.pyc' | xargs rm -f
+	find . -name '*.pyo' | xargs rm -f
+
+clean: clean-pyc
+	rm -rf venv2
+	rm -rf venv3

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -818,7 +818,7 @@ def add_tile_store(dataset_id, auto_process, **kwargs):
     return _create_dataset_backend(dataset_id, DatasetBackends.tile, auto_process, None, **kwargs)
 
 
-def add_capped_tile_store(dataset_id, auto_process, minimum_temporal_level, maximum_temporal_level, **kwargs):
+def add_capped_tile_store(dataset_id, auto_process, min_temporal_zoom_level, min_spatial_zoom_level, **kwargs):
     """
     Adds a capped tile store to the specified dataset.
 
@@ -832,16 +832,16 @@ def add_capped_tile_store(dataset_id, auto_process, minimum_temporal_level, maxi
     auto_process : boolean
         Configure the backend to auto process transactions. Auto processing is enabled by default.
         Set to False to disable auto processing.
-    minimum_temporal_level : integer
+    min_temporal_zoom_level : integer
         The lowest resolution temporal zoom level at which data will be tiled.
-    maximum_temporal_level : integer
+    min_spatial_zoom_level : integer
         The highest resolution temporal zoom level at which data will be tiled.
     **kwargs : key-value
         See :py:func:`make_post_request` for more kwargs.
     """
     config = {
-        'minimum_temporal_level': minimum_temporal_level,
-        'maximum_temporal_level': maximum_temporal_level,
+        'minimum_temporal_level': min_temporal_zoom_level,
+        'minimum_spatial_level': min_spatial_zoom_level,
     }
     return _create_dataset_backend(dataset_id, DatasetBackends.capped_tile, auto_process, config, **kwargs)
 

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -818,7 +818,7 @@ def add_tile_store(dataset_id, auto_process, **kwargs):
     return _create_dataset_backend(dataset_id, DatasetBackends.tile, auto_process, None, **kwargs)
 
 
-def add_capped_tile_store(dataset_id, auto_process, minimum_temoral_level, maximum_temporal_level, **kwargs):
+def add_capped_tile_store(dataset_id, auto_process, minimum_temporal_level, maximum_temporal_level, **kwargs):
     """
     Adds a capped tile store to the specified dataset.
 
@@ -832,11 +832,15 @@ def add_capped_tile_store(dataset_id, auto_process, minimum_temoral_level, maxim
     auto_process : boolean
         Configure the backend to auto process transactions. Auto processing is enabled by default.
         Set to False to disable auto processing.
+    minimum_temporal_level : integer
+        The lowest resolution temporal zoom level at which data will be tiled.
+    maximum_temporal_level : integer
+        The highest resolution temporal zoom level at which data will be tiled.
     **kwargs : key-value
         See :py:func:`make_post_request` for more kwargs.
     """
     config = {
-        'minimum_temporal_level': minimum_temoral_level,
+        'minimum_temporal_level': minimum_temporal_level,
         'maximum_temporal_level': maximum_temporal_level,
     }
     return _create_dataset_backend(dataset_id, DatasetBackends.capped_tile, auto_process, config, **kwargs)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -245,7 +245,7 @@ class Test(unittest.TestCase):
         result = api.list_api_keys(**test_kwargs)
         mock_make_get_request.assert_called_once_with(
             'apikeys/list', **test_kwargs)
-        self.assertEquals(result['apikey'], 'fake json content')
+        self.assertEqual(result['apikey'], 'fake json content')
 
     @mock.patch('conduce.api.make_post_request', return_value=ResultMock())
     def test_create_api_key(self, mock_make_post_request):
@@ -253,7 +253,7 @@ class Test(unittest.TestCase):
         result = api.create_api_key(**test_kwargs)
         mock_make_post_request.assert_called_once_with(
             {"description": "Generated and used by conduce-python-api"}, 'apikeys/create', **test_kwargs)
-        self.assertEquals(result, 'fake json content')
+        self.assertEqual(result, 'fake json content')
 
     @mock.patch('conduce.api.make_post_request')
     def test_remove_api_key(self, mock_make_post_request):
@@ -262,7 +262,7 @@ class Test(unittest.TestCase):
         result = api.remove_api_key(test_api_key, **test_kwargs)
         mock_make_post_request.assert_called_once_with(
             {'apikey': test_api_key}, 'apikeys/delete', **test_kwargs)
-        self.assertEquals(result, None)
+        self.assertEqual(result, None)
 
     @mock.patch('conduce.api.make_post_request', return_value=False)
     def test_account_exists(self, mock_make_post_request):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -51,13 +51,13 @@ class Test(unittest.TestCase):
         fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
         fake_dataset_id = 'fake-id'
         fake_auto_process = 'fake-auto_process'
-        fake_min = 'fake-min'
-        fake_max = 'fake-max'
-        api.add_capped_tile_store(fake_dataset_id, fake_auto_process, fake_min, fake_max, **fake_kwargs)
+        fake_temporal = 'fake-temporal'
+        fake_spatial = 'fake-spatial'
+        api.add_capped_tile_store(fake_dataset_id, fake_auto_process, fake_temporal, fake_spatial, **fake_kwargs)
 
         expected_config = {
-            'minimum_temporal_level': 'fake-min',
-            'maximum_temporal_level': 'fake-max',
+            'minimum_temporal_level': 'fake-temporal',
+            'minimum_spatial_level': 'fake-spatial',
         }
         mock__create_dataset_backend.assert_called_once_with(fake_dataset_id, api.DatasetBackends.capped_tile,
                                                              fake_auto_process, expected_config, **fake_kwargs)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -28,6 +28,104 @@ class CustomHTTPException:
 
 
 class Test(unittest.TestCase):
+    @mock.patch('conduce.api._create_dataset_backend', return_value=ResultMock())
+    def test_add_simple_store(self, mock__create_dataset_backend):
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        fake_dataset_id = 'fake-id'
+        fake_auto_process = 'fake-auto_process'
+        api.add_simple_store(fake_dataset_id, fake_auto_process, **fake_kwargs)
+        mock__create_dataset_backend.assert_called_once_with(fake_dataset_id, api.DatasetBackends.simple,
+                                                             fake_auto_process, None, **fake_kwargs)
+
+    @mock.patch('conduce.api._create_dataset_backend', return_value=ResultMock())
+    def test_add_tile_store(self, mock__create_dataset_backend):
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        fake_dataset_id = 'fake-id'
+        fake_auto_process = 'fake-auto_process'
+        api.add_tile_store(fake_dataset_id, fake_auto_process, **fake_kwargs)
+        mock__create_dataset_backend.assert_called_once_with(fake_dataset_id, api.DatasetBackends.tile,
+                                                             fake_auto_process, None, **fake_kwargs)
+
+    @mock.patch('conduce.api._create_dataset_backend', return_value=ResultMock())
+    def test_add_capped_tile_store(self, mock__create_dataset_backend):
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        fake_dataset_id = 'fake-id'
+        fake_auto_process = 'fake-auto_process'
+        fake_min = 'fake-min'
+        fake_max = 'fake-max'
+        api.add_capped_tile_store(fake_dataset_id, fake_auto_process, fake_min, fake_max, **fake_kwargs)
+
+        expected_config = {
+            'minimum_temporal_level': 'fake-min',
+            'maximum_temporal_level': 'fake-max',
+        }
+        mock__create_dataset_backend.assert_called_once_with(fake_dataset_id, api.DatasetBackends.capped_tile,
+                                                             fake_auto_process, expected_config, **fake_kwargs)
+
+    @mock.patch('conduce.api._create_dataset_backend', return_value=ResultMock())
+    def test_add_elasticsearch_store(self, mock__create_dataset_backend):
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        fake_dataset_id = 'fake-id'
+        fake_auto_process = 'fake-auto_process'
+        api.add_elasticsearch_store(fake_dataset_id, fake_auto_process, **fake_kwargs)
+        mock__create_dataset_backend.assert_called_once_with(fake_dataset_id, api.DatasetBackends.elasticsearch,
+                                                             fake_auto_process, None, **fake_kwargs)
+
+    @mock.patch('conduce.api._create_dataset_backend', return_value=ResultMock())
+    def test_add_histogram_store(self, mock__create_dataset_backend):
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        fake_dataset_id = 'fake-id'
+        fake_auto_process = 'fake-auto_process'
+        api.add_histogram_store(fake_dataset_id, fake_auto_process, **fake_kwargs)
+        mock__create_dataset_backend.assert_called_once_with(fake_dataset_id, api.DatasetBackends.histogram,
+                                                             fake_auto_process, None, **fake_kwargs)
+
+    def test__create_dataset_backend__invalid_backend(self):
+        with self.assertRaisesRegex(ValueError, 'The backend type specified is not valid.'):
+            api._create_dataset_backend('fake-id', 'invalid-backend-type', 'irrelevant', 'irrelevant')
+
+    @mock.patch('conduce.api.make_post_request', return_value=ResultMock())
+    def test__create_dataset_backend__simple(self, mock_make_post_request):
+        api._create_dataset_backend('fake-id', api.DatasetBackends.simple, None, None)
+        expected_payload = {
+            'backend_type': 'SimpleStore',
+            'auto_process': None,
+        }
+        mock_make_post_request.assert_called_once_with(expected_payload, '/api/v2/data/fake-id/backends')
+
+    @mock.patch('conduce.api.make_post_request', return_value=ResultMock())
+    def test__create_dataset_backend__kwargs_passthrough(self, mock_make_post_request):
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        api._create_dataset_backend('fake-id', api.DatasetBackends.simple, None, None, **fake_kwargs)
+        expected_payload = {
+            'backend_type': 'SimpleStore',
+            'auto_process': None,
+        }
+        mock_make_post_request.assert_called_once_with(expected_payload, '/api/v2/data/fake-id/backends', **fake_kwargs)
+
+    @mock.patch('conduce.api.make_post_request', return_value=ResultMock())
+    def test__create_dataset_backend__auto_process(self, mock_make_post_request):
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        api._create_dataset_backend('fake-id', api.DatasetBackends.simple, 'fake-auto-process', None, **fake_kwargs)
+        expected_payload = {
+            'backend_type': 'SimpleStore',
+            'auto_process': 'fake-auto-process',
+        }
+        mock_make_post_request.assert_called_once_with(expected_payload, '/api/v2/data/fake-id/backends', **fake_kwargs)
+
+    @mock.patch('conduce.api.make_post_request', return_value=ResultMock())
+    def test__create_dataset_backend__custom_config(self, mock_make_post_request):
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        fake_config = {'config1': 'config1', 'config2': 'config2'}
+        api._create_dataset_backend('fake-id', api.DatasetBackends.simple, None, fake_config, **fake_kwargs)
+        expected_payload = {
+            'backend_type': 'SimpleStore',
+            'auto_process': None,
+            'config1': 'config1',
+            'config2': 'config2'
+        }
+        mock_make_post_request.assert_called_once_with(expected_payload, '/api/v2/data/fake-id/backends', **fake_kwargs)
+
     @mock.patch('conduce.api.make_delete_request', return_value=ResultMock())
     def test_delete_transactions(self, mock_make_get_request):
         fake_id = 'fake-id'


### PR DESCRIPTION
Adds generic method to create a backend, only valid backend types are accepted.

Adds convenience methods for all valid backend types.

No CLI support in this PR.