### PR TITLE
SKW-4168: other backends methods

### DIFF
--- a/conduce/api.py
+++ b/conduce/api.py
@@ -778,6 +778,22 @@ def delete_transactions(dataset_id, **kwargs):
     return make_delete_request(fragment, **kwargs)
 
 
+def get_dataset_backends(dataset_id, **kwargs):
+    """
+    Retrieves the list of backend UUIDs associated with the specified dataset.
+
+    If no backends are found, the list is empty.
+
+    Parameters
+    ----------
+    dataset_id : string
+        The UUID that identifies the dataset to which the backend belongs.
+    **kwargs : key-value
+        See :py:func:`make_get_request` for more kwargs.
+    """
+    return make_get_request('/api/v2/data/{}/backends'.format(dataset_id), **kwargs)
+
+
 def process_transactions(dataset_id, backend_id, **kwargs):
     """
     Process transactions on a dataset backend

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -778,7 +778,55 @@ def delete_transactions(dataset_id, **kwargs):
     return make_delete_request(fragment, **kwargs)
 
 
-def get_dataset_backends(dataset_id, **kwargs):
+def search_dataset_backend(dataset_id, backend_id, query, **kwargs):
+    """
+    Remove all data from the backend, remove the backend from the dataset.  Delete the backend.
+
+    Parameters
+    ----------
+    dataset_id : string
+        The UUID that identifies the dataset to which the backend belongs.
+    backend_id : string
+        The UUID that identifies the dataset backend to update.
+    **kwargs : key-value
+        See :py:func:`make_delete_request` for more kwargs.
+    """
+    return make_post_request(query, '/api/v2/data/{}/backends/{}/searches'.format(dataset_id, backend_id), **kwargs)
+
+
+def remove_dataset_backend(dataset_id, backend_id, **kwargs):
+    """
+    Remove all data from the backend, remove the backend from the dataset.  Delete the backend.
+
+    Parameters
+    ----------
+    dataset_id : string
+        The UUID that identifies the dataset to which the backend belongs.
+    backend_id : string
+        The UUID that identifies the dataset backend to update.
+    **kwargs : key-value
+        See :py:func:`make_delete_request` for more kwargs.
+    """
+    return make_delete_request('/api/v2/data/{}/backends/{}'.format(dataset_id, backend_id), **kwargs)
+
+
+def get_dataset_backend_metadata(dataset_id, backend_id, **kwargs):
+    """
+    Retrieves dataset backend metadata.
+
+    Parameters
+    ----------
+    dataset_id : string
+        The UUID that identifies the dataset to which the backend belongs.
+    backend_id : string
+        The UUID that identifies the dataset backend to update.
+    **kwargs : key-value
+        See :py:func:`make_get_request` for more kwargs.
+    """
+    return make_get_request('/api/v2/data/{}/backends/{}'.format(dataset_id, backend_id), **kwargs)
+
+
+def list_dataset_backends(dataset_id, **kwargs):
     """
     Retrieves the list of backend UUIDs associated with the specified dataset.
 

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -780,7 +780,7 @@ def delete_transactions(dataset_id, **kwargs):
 
 def search_dataset_backend(dataset_id, backend_id, query, **kwargs):
     """
-    Remove all data from the backend, remove the backend from the dataset.  Delete the backend.
+    Retrieves data from the dataset matching the query provided.
 
     Parameters
     ----------
@@ -788,10 +788,18 @@ def search_dataset_backend(dataset_id, backend_id, query, **kwargs):
         The UUID that identifies the dataset to which the backend belongs.
     backend_id : string
         The UUID that identifies the dataset backend to update.
+    query: dictionary
+        Query parameters.
     **kwargs : key-value
         See :py:func:`make_delete_request` for more kwargs.
+
+    Returns
+    -------
+    list
+        A list of entities matching the specified query
     """
-    return make_post_request(query, '/api/v2/data/{}/backends/{}/searches'.format(dataset_id, backend_id), **kwargs)
+    response = make_post_request(query, '/api/v2/data/{}/backends/{}/searches'.format(dataset_id, backend_id), **kwargs)
+    return json.loads(response.content)
 
 
 def remove_dataset_backend(dataset_id, backend_id, **kwargs):

--- a/conduce/api.py
+++ b/conduce/api.py
@@ -778,6 +778,97 @@ def delete_transactions(dataset_id, **kwargs):
     return make_delete_request(fragment, **kwargs)
 
 
+def process_transactions(dataset_id, backend_id, **kwargs):
+    """
+    Process transactions on a dataset backend
+
+    Parameters
+    ----------
+    dataset_id : string
+        The UUID that identifies the dataset to which the backend belongs.
+    backend_id : string
+        The UUID that identifies the dataset backend to update.
+    **kwargs : key-value
+        **all**
+            Process all outstanding transactions to the specified backend
+        **transaction**
+            Process a specific transaction to the specified backend
+        **min**
+            The oldest transaction in the sequence to be processed to the backend
+        **max**
+            The newest transaction in the sequence to be processed to the backend
+        **default**
+            Make this backend the default backend. Set to any value, all other parameters are ignored.
+        See :py:func:`make_patch_request` for more kwargs.
+
+    Returns
+    -------
+    requests.Response
+         On success, an asynchronous job ID.  Check the job status for progress.
+         (See :py:func:`wait_for_job`)
+    """
+
+    fragment = '/api/v2/data/{}/backends/{}'.format(dataset_id, backend_id)
+    parameters = {
+        'all': bool(kwargs.get('all')),
+        'tx': kwargs.get('transaction'),
+        'min': kwargs.get('min'),
+        'max': kwargs.get('max'),
+        'default': kwargs.get('default'),
+    }
+
+    # HACK: Remove when boolean parameters are supported
+    if not kwargs.get('all'):
+        parameters.pop('all')
+
+    return make_patch_request({}, fragment, parameters=parameters, **kwargs)
+
+
+def enable_auto_processing(dataset_id, backend_id, enable=True, **kwargs):
+    """
+    Configure a dataset backend to automatically process new transactions
+
+    Parameters
+    ----------
+    dataset_id : string
+        The UUID that identifies the dataset to which the backend belongs.
+    backend_id : string
+        The UUID that identifies the dataset backend to update.
+    **kwargs : key-value
+        **enable**
+            When True (default) enables auto processing.  Set to False to disable, or call :py:func:`disable_auto_processing`.
+        See :py:func:`make_patch_request` for more kwargs.
+    """
+
+    fragment = '/api/v2/data/{}/backends/{}'.format(dataset_id, backend_id)
+    payload = [
+        {
+            "path": "/auto_process",
+            "value": enable,
+            "op": "add"
+        }
+    ]
+    return make_patch_request(payload, fragment, **kwargs)
+
+
+def disable_auto_processing(dataset_id, backend_id, **kwargs):
+    """
+    Configure a dataset backend to ignore new transactions
+
+    Transactions can be triggered to process to the backend manually using :py:func:`process_transactions`.
+
+    Parameters
+    ----------
+    dataset_id : string
+        The UUID that identifies the dataset to which the backend belongs.
+    backend_id : string
+        The UUID that identifies the dataset backend to update.
+    **kwargs : key-value
+        See :py:func:`make_patch_request` for kwargs.
+    """
+    return enable_auto_processing(dataset_id, backend_id, False, **kwargs)
+
+
 def add_simple_store(dataset_id, auto_process, **kwargs):
     """
     Adds a simple store to the specified dataset.

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -28,12 +28,45 @@ class CustomHTTPException:
 
 
 class Test(unittest.TestCase):
+    @mock.patch('conduce.api.make_post_request', return_value=ResultMock())
+    def test_search_dataset_backend(self, mock_make_post_request):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_backend_id = 'fake-backend-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+
+        api.search_dataset_backend(fake_dataset_id, fake_backend_id, 'fake-query', **fake_kwargs)
+
+        expected_fragment = '/api/v2/data/{}/backends/{}/searches'.format(fake_dataset_id, fake_backend_id)
+        mock_make_post_request.assert_called_once_with('fake-query', expected_fragment, **fake_kwargs)
+
+    @mock.patch('conduce.api.make_delete_request', return_value=ResultMock())
+    def test_delete_dataset_backend(self, mock_make_delete_request):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_backend_id = 'fake-backend-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+
+        api.remove_dataset_backend(fake_dataset_id, fake_backend_id, **fake_kwargs)
+
+        expected_fragment = '/api/v2/data/{}/backends/{}'.format(fake_dataset_id, fake_backend_id)
+        mock_make_delete_request.assert_called_once_with(expected_fragment, **fake_kwargs)
+
     @mock.patch('conduce.api.make_get_request', return_value=ResultMock())
-    def test_get_dataset_backends(self, mock_make_get_request):
+    def test_get_dataset_backend_metadata(self, mock_make_get_request):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_backend_id = 'fake-backend-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+
+        api.get_dataset_backend_metadata(fake_dataset_id, fake_backend_id, **fake_kwargs)
+
+        expected_fragment = '/api/v2/data/{}/backends/{}'.format(fake_dataset_id, fake_backend_id)
+        mock_make_get_request.assert_called_once_with(expected_fragment, **fake_kwargs)
+
+    @mock.patch('conduce.api.make_get_request', return_value=ResultMock())
+    def test_list_dataset_backends(self, mock_make_get_request):
         fake_dataset_id = 'fake-dataset-id'
         fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
 
-        api.get_dataset_backends(fake_dataset_id, **fake_kwargs)
+        api.list_dataset_backends(fake_dataset_id, **fake_kwargs)
 
         expected_fragment = '/api/v2/data/{}/backends'.format(fake_dataset_id)
         mock_make_get_request.assert_called_once_with(expected_fragment, **fake_kwargs)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -34,7 +34,8 @@ class Test(unittest.TestCase):
         fake_backend_id = 'fake-backend-id'
         fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
 
-        api.search_dataset_backend(fake_dataset_id, fake_backend_id, 'fake-query', **fake_kwargs)
+        expected_response = {'apikey': 'fake json content'}
+        self.assertEqual(api.search_dataset_backend(fake_dataset_id, fake_backend_id, 'fake-query', **fake_kwargs), expected_response)
 
         expected_fragment = '/api/v2/data/{}/backends/{}/searches'.format(fake_dataset_id, fake_backend_id)
         mock_make_post_request.assert_called_once_with('fake-query', expected_fragment, **fake_kwargs)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -28,6 +28,98 @@ class CustomHTTPException:
 
 
 class Test(unittest.TestCase):
+    @mock.patch('conduce.api.make_patch_request', return_value=ResultMock())
+    def test_disable_auto_processing(self, mock_make_patch_request):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_backend_id = 'fake-backend-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+
+        api.disable_auto_processing(fake_dataset_id, fake_backend_id, **fake_kwargs)
+
+        expected_fragment = '/api/v2/data/{}/backends/{}'.format(fake_dataset_id, fake_backend_id)
+        expected_payload = [
+            {
+                "path": "/auto_process",
+                "value": False,
+                "op": "add"
+            }
+        ]
+        mock_make_patch_request.assert_called_once_with(expected_payload, expected_fragment, **fake_kwargs)
+
+    @mock.patch('conduce.api.make_patch_request', return_value=ResultMock())
+    def test_enable_auto_processing__disable(self, mock_make_patch_request):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_backend_id = 'fake-backend-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+
+        api.enable_auto_processing(fake_dataset_id, fake_backend_id, enable=False, **fake_kwargs)
+
+        expected_fragment = '/api/v2/data/{}/backends/{}'.format(fake_dataset_id, fake_backend_id)
+        expected_payload = [
+            {
+                "path": "/auto_process",
+                "value": False,
+                "op": "add"
+            }
+        ]
+        mock_make_patch_request.assert_called_once_with(expected_payload, expected_fragment, **fake_kwargs)
+
+    @mock.patch('conduce.api.make_patch_request', return_value=ResultMock())
+    def test_enable_auto_processing__default(self, mock_make_patch_request):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_backend_id = 'fake-backend-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+
+        api.enable_auto_processing(fake_dataset_id, fake_backend_id, **fake_kwargs)
+
+        expected_fragment = '/api/v2/data/{}/backends/{}'.format(fake_dataset_id, fake_backend_id)
+        expected_payload = [
+            {
+                "path": "/auto_process",
+                "value": True,
+                "op": "add"
+            }
+        ]
+        mock_make_patch_request.assert_called_once_with(expected_payload, expected_fragment, **fake_kwargs)
+
+    @mock.patch('conduce.api.make_patch_request', return_value=ResultMock())
+    def test_process_transactions__parameters_set(self, mock_make_patch_request):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_backend_id = 'fake-backend-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2', 'all': True, 'transaction': 'fake-transaction',
+                       'min': 'fake-min', 'max': 'fake-max', 'default': 'fake-default'}
+
+        api.process_transactions(fake_dataset_id, fake_backend_id, **fake_kwargs)
+
+        expected_fragment = '/api/v2/data/{}/backends/{}'.format(fake_dataset_id, fake_backend_id)
+        expected_parameters = {
+            'all': bool(fake_kwargs.get('all')),
+            'tx': fake_kwargs.get('transaction'),
+            'min': fake_kwargs.get('min'),
+            'max': fake_kwargs.get('max'),
+            'default': fake_kwargs.get('default'),
+        }
+
+        mock_make_patch_request.assert_called_once_with({}, expected_fragment, parameters=expected_parameters, **fake_kwargs)
+
+    @mock.patch('conduce.api.make_patch_request', return_value=ResultMock())
+    def test_process_transactions(self, mock_make_patch_request):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_backend_id = 'fake-backend-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+
+        api.process_transactions(fake_dataset_id, fake_backend_id, **fake_kwargs)
+
+        expected_fragment = '/api/v2/data/{}/backends/{}'.format(fake_dataset_id, fake_backend_id)
+        expected_parameters = {
+            'tx': fake_kwargs.get('transaction'),
+            'min': fake_kwargs.get('min'),
+            'max': fake_kwargs.get('max'),
+            'default': fake_kwargs.get('default'),
+        }
+
+        mock_make_patch_request.assert_called_once_with({}, expected_fragment, parameters=expected_parameters, **fake_kwargs)
+
     @mock.patch('conduce.api._create_dataset_backend', return_value=ResultMock())
     def test_add_simple_store(self, mock__create_dataset_backend):
         fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -28,6 +28,16 @@ class CustomHTTPException:
 
 
 class Test(unittest.TestCase):
+    @mock.patch('conduce.api.make_get_request', return_value=ResultMock())
+    def test_get_dataset_backends(self, mock_make_get_request):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+
+        api.get_dataset_backends(fake_dataset_id, **fake_kwargs)
+
+        expected_fragment = '/api/v2/data/{}/backends'.format(fake_dataset_id)
+        mock_make_get_request.assert_called_once_with(expected_fragment, **fake_kwargs)
+
     @mock.patch('conduce.api.make_patch_request', return_value=ResultMock())
     def test_disable_auto_processing(self, mock_make_patch_request):
         fake_dataset_id = 'fake-dataset-id'


### PR DESCRIPTION
Add method to get backends (1 method) and methods (3) to patch backends (process transactions and set auto_process flag).

No CLI support in this PR.  Builds on create backend methods.

EDIT: Also contains methods for get backend metadata, delete backend, and search backend.