### PR TITLE
Do pyenv the right way

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 deps: setup-env deps-venv2 deps-venv3
 
 setup-env: venv2 venv3 
@@ -5,11 +6,19 @@ setup-env: venv2 venv3
 venv2:
 	mkdir -p venv2
 	pyenv install -s 2.7.16
+ifneq "$(shell PYENV_VERSION=2.7.16 python -V 2>&1)" "Python 2.7.16"
+	echo "pyenv not configured correctly, check your configuration"
+	exit 1
+endif
 	PYENV_VERSION=2.7.16 virtualenv venv2
 
 venv3:
 	mkdir -p venv3
 	pyenv install -s 3.7.4
+ifneq "$(shell PYENV_VERSION=3.7.4 python -V 2>&1)" "Python 3.7.4"
+	echo "pyenv not configured correctly, check your configuration"
+	exit 1
+endif
 	PYENV_VERSION=3.7.4 python -m venv venv3
 
 deps-venv2: venv2 requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,13 @@ setup-env: venv2 venv3
 
 venv2:
 	mkdir -p venv2
-	cd venv2
 	pyenv install -s 2.7.16
-	pyenv local 2.7.16
-	cd ..
-	virtualenv venv2
+	PYENV_VERSION=2.7.16 virtualenv venv2
 
 venv3:
 	mkdir -p venv3
-	cd venv3
 	pyenv install -s 3.7.4
-	pyenv local 3.7.4
-	cd ..
-	python -m venv venv3 
+	PYENV_VERSION=3.7.4 python -m venv venv3
 
 deps-venv2: venv2 requirements-dev.txt
 	./venv2/bin/pip install -r requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -6,20 +6,20 @@ setup-env: venv2 venv3
 venv2:
 	mkdir -p venv2
 	pyenv install -s 2.7.16
-ifneq "$(shell PYENV_VERSION=2.7.16 python -V 2>&1)" "Python 2.7.16"
+ifneq "$(shell PYENV_VERSION=2.7.16 pyenv exec python -V 2>&1)" "Python 2.7.16"
 	echo "pyenv not configured correctly, check your configuration"
 	exit 1
 endif
-	PYENV_VERSION=2.7.16 virtualenv venv2
+	PYENV_VERSION=2.7.16 pyenv exec virtualenv venv2
 
 venv3:
 	mkdir -p venv3
 	pyenv install -s 3.7.4
-ifneq "$(shell PYENV_VERSION=3.7.4 python -V 2>&1)" "Python 3.7.4"
+ifneq "$(shell PYENV_VERSION=3.7.4 pyenv exec python -V 2>&1)" "Python 3.7.4"
 	echo "pyenv not configured correctly, check your configuration"
 	exit 1
 endif
-	PYENV_VERSION=3.7.4 python -m venv venv3
+	PYENV_VERSION=3.7.4 pyenv exec python -m venv venv3
 
 deps-venv2: venv2 requirements-dev.txt
 	./venv2/bin/pip install -r requirements-dev.txt


### PR DESCRIPTION
This change uses the PYENV_VERSION environment variable instead of the `pyenv local` command to set the python version when creating virtual environments.  Once the virtual environments are created pyenv has done its job and is no longer required.