### PR TITLE
SKW-4169: update create dataset

### DIFF
--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -267,7 +267,12 @@ def list_datasets(args):
 
 
 def create_dataset(args):
-    response = api.create_dataset(args.name, **vars(args))
+    backend_types = []
+    if len(args.backends) > 0:
+        for backend in args.backends:
+            backend_types.append(api.DatasetBackends.BACKEND_TYPES[backend.replace('-', '_')])
+
+    response = api.create_dataset(args.name, backend_types=backend_types, **request_kwargs(**vars(args)))
 
     if args.json or args.csv:
         print(json.dumps(response, indent=2))
@@ -1087,15 +1092,9 @@ def main():
     parser_remove_api_key.add_argument('key', help='The key to delete')
     parser_remove_api_key.set_defaults(func=remove_api_key)
 
-    parser_create_dataset = subparsers.add_parser('create-dataset', parents=[api_cmd_parser], help='Create a Conduce dataset')
+    parser_create_dataset = subparsers.add_parser('create-dataset', parents=[api_cmd_parser, dataset_post_transaction_parser], help='Create a Conduce dataset')
     parser_create_dataset.add_argument('name', help='The name to be given to the new dataset')
-    parser_create_dataset.add_argument('--json', help='Optional: A JSON file that can parsed into Conduce entities')
-    parser_create_dataset.add_argument('--csv', help='Optional: A CSV file that can be parsed as Conduce data')
-    parser_create_dataset.add_argument('--raw', help='Optional: A well formatted Conduce entities JSON file. Ignores --kind, --generate-ids and --answer-yes')
-    parser_create_dataset.add_argument('--generate-ids', help='Set this flag if the data does not contain an ID field', action='store_true')
-    parser_create_dataset.add_argument('--kind', help='Use this value as the kind for all entities')
-    parser_create_dataset.add_argument('--answer-yes', help='Set this flag to answer yes at all prompts', action='store_true')
-    parser_create_dataset.add_argument('--debug', help='Get better information about errors', action='store_true')
+    parser_create_dataset.add_argument('backends', nargs='*', help='Backends with which to create the dataset')
     parser_create_dataset.set_defaults(func=create_dataset)
 
     parser_create_tileset = subparsers.add_parser('create-tileset', parents=[api_cmd_parser], help='Create a Conduce tileset')
@@ -1105,15 +1104,9 @@ def main():
     parser_create_tileset.add_argument('--tile-json', help='A valid TileJSON file')
     parser_create_tileset.set_defaults(func=create_tileset)
 
-    parser_ingest_data = subparsers.add_parser('ingest-data', parents=[api_cmd_parser], help='Ingest data to a Conduce dataset')
+    parser_ingest_data = subparsers.add_parser(
+        'ingest-data', parents=[api_cmd_parser, dataset_post_transaction_parser], help='Ingest data to a Conduce dataset')
     parser_ingest_data.add_argument('dataset_id', help='The ID of the dataset to receive the entities')
-    parser_ingest_data.add_argument('--json', help='A JSON file that can parsed into Conduce entities')
-    parser_ingest_data.add_argument('--csv', help='A CSV file that can be parsed as Conduce data')
-    parser_ingest_data.add_argument('--raw', help='A well formatted Conduce entities JSON file. Ignores --kind, --generate-ids and --answer-yes')
-    parser_ingest_data.add_argument('--generate-ids', help='Set this flag if the data does not contain an ID field', action='store_true')
-    parser_ingest_data.add_argument('--kind', help='Use this value as the kind for all entities')
-    parser_ingest_data.add_argument('--answer-yes', help='Set this flag to answer yes at all prompts', action='store_true')
-    parser_ingest_data.add_argument('--debug', help='Get better information about errors', action='store_true')
     parser_ingest_data.set_defaults(func=ingest_data)
 
     parser_dump_data = subparsers.add_parser('dump-data', parents=[api_cmd_parser], help='dump all data from a Conduce dataset')

--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -919,6 +919,7 @@ def main():
     parser_dataset_create = parser_dataset_subparsers.add_parser(
         'create', parents=[api_cmd_parser, dataset_post_transaction_parser], help='Create a new dataset with optional data')
     parser_dataset_create.add_argument('name', help='The name to be given to the new dataset')
+    parser_dataset_create.add_argument('backends', nargs='*', help='Backends with which to create the dataset')
     parser_dataset_create.set_defaults(func=create_dataset)
 
     parser_dataset_append = parser_dataset_subparsers.add_parser(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -2,6 +2,7 @@ import unittest
 import mock
 
 from conduce import cli
+from conduce import api
 
 # Python 2 compatibility
 try:
@@ -76,6 +77,127 @@ class Test(unittest.TestCase):
         mock_api_list_dataset_backends.assert_has_calls(expected_list_dataset_backend_calls)
         mock_api_get_transactions.assert_has_calls(expected_get_transaction_count_calls)
         mock_api_get_dataset_backend_metadata.assert_has_calls(expected_get_metadata_calls)
+
+    @mock.patch('conduce.api.create_dataset', return_value={'id': 'fake-dataset-id'})
+    @mock.patch('conduce.ingest.ingest_file')
+    @mock.patch('conduce.cli.ingest_entities')
+    def test_create_dataset__raw(
+            self,
+            mock_ingest_entities,
+            mock_ingest_file,
+            mock_api_create_dataset,
+    ):
+        fake_dataset_name = 'fake-dataset-name'
+        fake_backend_types = []
+        fake_json = 'fake-json'
+        fake_passed_args = FakeArgs(host='fake-host', user='fake-user')
+        fake_args = FakeArgs(name=fake_dataset_name, backends=fake_backend_types, csv=None, raw=fake_json, json=None, **vars(fake_passed_args))
+
+        cli.create_dataset(fake_args)
+        mock_ingest_file.assert_not_called()
+        mock_ingest_entities.assert_called_once_with('fake-dataset-id', fake_args)
+        mock_api_create_dataset.assert_called_once_with(fake_dataset_name, backend_types=fake_backend_types, **vars(fake_passed_args))
+
+    @mock.patch('conduce.api.create_dataset', return_value={'id': 'fake-dataset-id'})
+    @mock.patch('conduce.ingest.ingest_file')
+    @mock.patch('conduce.cli.ingest_entities')
+    def test_create_dataset__json(
+            self,
+            mock_ingest_entities,
+            mock_ingest_file,
+            mock_api_create_dataset,
+    ):
+        fake_dataset_name = 'fake-dataset-name'
+        fake_backend_types = []
+        fake_json = 'fake-json'
+        fake_passed_args = FakeArgs(host='fake-host', user='fake-user')
+        fake_args = FakeArgs(name=fake_dataset_name, backends=fake_backend_types, csv=None, json=fake_json, raw=None, **vars(fake_passed_args))
+
+        cli.create_dataset(fake_args)
+        mock_ingest_entities.assert_not_called()
+        mock_ingest_file.assert_called_once_with('fake-dataset-id', **vars(fake_args))
+        mock_api_create_dataset.assert_called_once_with(fake_dataset_name, backend_types=fake_backend_types, **vars(fake_passed_args))
+
+    @mock.patch('conduce.api.create_dataset', return_value={'id': 'fake-dataset-id'})
+    @mock.patch('conduce.ingest.ingest_file')
+    @mock.patch('conduce.cli.ingest_entities')
+    def test_create_dataset__csv(
+            self,
+            mock_ingest_entities,
+            mock_ingest_file,
+            mock_api_create_dataset,
+    ):
+        fake_dataset_name = 'fake-dataset-name'
+        fake_backend_types = []
+        fake_csv = 'fake-csv'
+        fake_passed_args = FakeArgs(host='fake-host', user='fake-user')
+        fake_args = FakeArgs(name=fake_dataset_name, backends=fake_backend_types, json=None, csv=fake_csv, raw=None, **vars(fake_passed_args))
+
+        cli.create_dataset(fake_args)
+        mock_ingest_entities.assert_not_called()
+        mock_ingest_file.assert_called_once_with('fake-dataset-id', **vars(fake_args))
+        mock_api_create_dataset.assert_called_once_with(fake_dataset_name, backend_types=fake_backend_types, **vars(fake_passed_args))
+
+    @mock.patch('conduce.api.create_dataset')
+    @mock.patch('conduce.ingest.ingest_file')
+    @mock.patch('conduce.cli.ingest_entities')
+    def test_create_dataset__backends(
+            self,
+            mock_ingest_entities,
+            mock_ingest_file,
+            mock_api_create_dataset,
+    ):
+        fake_dataset_name = 'fake-dataset-name'
+        fake_backend_types = ['simple', 'histogram', 'capped-tile']
+        fake_passed_args = FakeArgs(host='fake-host', user='fake-user')
+        fake_args = FakeArgs(name=fake_dataset_name, backends=fake_backend_types, json=None, csv=None, raw=None, **vars(fake_passed_args))
+
+        cli.create_dataset(fake_args)
+        mock_ingest_entities.assert_not_called()
+        mock_ingest_file.assert_not_called()
+        mock_api_create_dataset.assert_called_once_with(
+            fake_dataset_name,
+            backend_types=['SimpleStore', 'HistogramStore', 'CappedTileStore'],
+            **vars(fake_passed_args))
+
+    @mock.patch('conduce.api.create_dataset')
+    @mock.patch('conduce.ingest.ingest_file')
+    @mock.patch('conduce.cli.ingest_entities')
+    def test_create_dataset__raises_key_error(
+            self,
+            mock_ingest_entities,
+            mock_ingest_file,
+            mock_api_create_dataset,
+    ):
+        fake_dataset_name = 'fake-dataset-name'
+        fake_backend_types = ['fake_backend_types']
+        fake_passed_args = FakeArgs(host='fake-host', user='fake-user')
+        fake_args = FakeArgs(name=fake_dataset_name, backends=fake_backend_types, json=None, csv=None, raw=None, **vars(fake_passed_args))
+
+        with self.assertRaises(KeyError):
+            cli.create_dataset(fake_args)
+        mock_ingest_entities.assert_not_called()
+        mock_ingest_file.assert_not_called()
+        mock_api_create_dataset.assert_not_called()
+
+    @mock.patch('conduce.api.create_dataset')
+    @mock.patch('conduce.ingest.ingest_file')
+    @mock.patch('conduce.cli.ingest_entities')
+    def test_create_dataset__default(
+            self,
+            mock_ingest_entities,
+            mock_ingest_file,
+            mock_api_create_dataset,
+    ):
+        fake_dataset_name = 'fake-dataset-name'
+        fake_backend_types = []
+        fake_passed_args = FakeArgs(host='fake-host', user='fake-user')
+        fake_args = FakeArgs(name=fake_dataset_name, backends=fake_backend_types, json=None, csv=None, raw=None, **vars(fake_passed_args))
+
+        cli.create_dataset(fake_args)
+        mock_ingest_entities.assert_not_called()
+        mock_ingest_file.assert_not_called()
+        mock_api_create_dataset.assert_called_once_with(fake_dataset_name, backend_types=fake_backend_types, **vars(fake_passed_args))
 
     @mock.patch('conduce.api.enable_auto_processing', return_value=MockResponse())
     def test_enable_auto_processing__disable_True(self, mock_api_enable_auto_processing):


### PR DESCRIPTION
Updates create dataset to process an additional kwarg backend_types (list).  When backend types are defined and valid the default backend is removed and backends of the type in the array are added.

Also updates CLI for `dataset create` and `create-dataset`.