### PR TITLE
Remove min/max if value specified

### DIFF
--- a/conduce/cli.py
+++ b/conduce/cli.py
@@ -318,6 +318,9 @@ def insert_transaction(args):
 def get_dataset_transactions(args):
     dataset_id = args.dataset_id
     del vars(args)['dataset_id']
+    if args.value:
+        del vars(args)['min']
+        del vars(args)['max']
     return api.get_transactions(dataset_id, **vars(args))
 
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -463,9 +463,29 @@ class Test(unittest.TestCase):
         mock_read_entity_set_from_samples_file.assert_called_once_with(fake_args)
 
     @mock.patch('conduce.api.get_transactions', return_value=MockResponse())
-    def test_get_dataset_transactions(self, mock_api_get_transactions):
+    def test_get_dataset_transactions_set_value(self, mock_api_get_transactions):
         fake_dataset_id = 'fake-dataset-id'
-        fake_passed_args = FakeArgs(host='fake-host', user='fake-user')
+        fake_passed_args = FakeArgs(value=13, host='fake-host', user='fake-user')
+        fake_args = FakeArgs(dataset_id=fake_dataset_id, min=1, max=15, **vars(fake_passed_args))
+
+        cli.get_dataset_transactions(fake_args)
+
+        mock_api_get_transactions.assert_called_once_with(fake_dataset_id, **vars(fake_passed_args))
+
+    @mock.patch('conduce.api.get_transactions', return_value=MockResponse())
+    def test_get_dataset_transactions_set_min_max(self, mock_api_get_transactions):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_passed_args = FakeArgs(min=1, max=15, value=None, host='fake-host', user='fake-user')
+        fake_args = FakeArgs(dataset_id=fake_dataset_id, **vars(fake_passed_args))
+
+        cli.get_dataset_transactions(fake_args)
+
+        mock_api_get_transactions.assert_called_once_with(fake_dataset_id, **vars(fake_passed_args))
+
+    @mock.patch('conduce.api.get_transactions', return_value=MockResponse())
+    def test_get_dataset_transactions_default(self, mock_api_get_transactions):
+        fake_dataset_id = 'fake-dataset-id'
+        fake_passed_args = FakeArgs(min=-1, max=None, value=None, host='fake-host', user='fake-user')
         fake_args = FakeArgs(dataset_id=fake_dataset_id, **vars(fake_passed_args))
 
         cli.get_dataset_transactions(fake_args)


### PR DESCRIPTION
min defaults to -1 in the CLI.  This change causes value to override min/max rather than print an error.

An alternative would be to only remove min if -1 and value specified.