### PR TITLE
Try to parse timestamp instead of casting to float

### DIFF
--- a/conduce/util.py
+++ b/conduce/util.py
@@ -150,7 +150,7 @@ def get_timestamp_score(key, value):
         score += 200
 
     try:
-        float(value)
+        string_to_timestamp_ms(value)
         return score
     except Exception:
         pass


### PR DESCRIPTION
This change enables parsing from user data with timestamps in ISO8601 format or other formats supported by our `string_to_timestamp_ms` method.