### PR TITLE
Remove default from process transactions

### DIFF
--- a/conduce/api.py
+++ b/conduce/api.py
@@ -976,8 +976,6 @@ def process_transactions(dataset_id, backend_id, **kwargs):
             The oldest transaction in the sequence to be processed to the backend
         **max**
             The newest transaction in the sequence to be processed to the backend
-        **default**
-            Make this backend the default backend. Set to any value, all other parameters are ignored.
         See :py:func:`make_patch_request` for more kwargs.
 
     Returns
@@ -993,7 +991,6 @@ def process_transactions(dataset_id, backend_id, **kwargs):
         'tx': kwargs.get('transaction'),
         'min': kwargs.get('min'),
         'max': kwargs.get('max'),
-        'default': kwargs.get('default'),
     }
 
     # HACK: Remove when boolean parameters are supported

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -355,7 +355,7 @@ class Test(unittest.TestCase):
         fake_dataset_id = 'fake-dataset-id'
         fake_backend_id = 'fake-backend-id'
         fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2', 'all': True, 'transaction': 'fake-transaction',
-                       'min': 'fake-min', 'max': 'fake-max', 'default': 'fake-default'}
+                       'min': 'fake-min', 'max': 'fake-max'}
 
         api.process_transactions(fake_dataset_id, fake_backend_id, **fake_kwargs)
 
@@ -365,7 +365,6 @@ class Test(unittest.TestCase):
             'tx': fake_kwargs.get('transaction'),
             'min': fake_kwargs.get('min'),
             'max': fake_kwargs.get('max'),
-            'default': fake_kwargs.get('default'),
         }
 
         mock_make_patch_request.assert_called_once_with({}, expected_fragment, parameters=expected_parameters, **fake_kwargs)
@@ -383,7 +382,6 @@ class Test(unittest.TestCase):
             'tx': fake_kwargs.get('transaction'),
             'min': fake_kwargs.get('min'),
             'max': fake_kwargs.get('max'),
-            'default': fake_kwargs.get('default'),
         }
 
         mock_make_patch_request.assert_called_once_with({}, expected_fragment, parameters=expected_parameters, **fake_kwargs)


### PR DESCRIPTION
There is a method dedicated to setting the default backend.  It is confusing to include it here.