### PR TITLE
Updated for clarity

### DIFF
--- a/conduce/api.py
+++ b/conduce/api.py
@@ -757,7 +757,7 @@ def post_transaction(dataset_id, entity_set, **kwargs):
         raise ValueError("Parameter entity_set is not an 'entities' dict.")
 
     if kwargs.get('debug'):
-        kwargs['debug'] = False
+        kwargs.pop('debug')
         kwargs['process'] = True
         print("Debug ingest")
         responses = []
@@ -768,15 +768,16 @@ def post_transaction(dataset_id, entity_set, **kwargs):
             print("{} / {} ingested".format(idx, len(entity_set['entities'])))
         return responses
 
+    process = bool(kwargs.pop('process', False))
     payload = {
         'data': entity_set,
         'op': kwargs.get('operation', 'INSERT'),
     }
     response = make_post_request(
-        payload, '/api/v2/data/{}/transactions?process={}'.format(dataset_id, bool(kwargs.get('process', False))), **kwargs)
+        payload, '/api/v2/data/{}/transactions?process={}'.format(dataset_id, process), **kwargs)
     response.raise_for_status()
 
-    if kwargs.get('process', False):
+    if process:
         if response.status_code == 202:
             if 'location' in response.headers:
                 job_id = response.headers['location']

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -678,8 +678,8 @@ class Test(unittest.TestCase):
     def test_post_transaction__process_true(self, mock_make_post_request):
         fake_id = 'fake_id'
         fake_entities = {'entities': 'fake entities'}
-        fake_kwargs = {'arg1': 'arg1', 'process': True}
-        self.assertIsInstance(api.post_transaction(fake_id, fake_entities, **fake_kwargs), ResultMock_201)
+        fake_kwargs = {'arg1': 'arg1', 'arg2': 'arg2'}
+        self.assertIsInstance(api.post_transaction(fake_id, fake_entities, process=True, **fake_kwargs), ResultMock_201)
 
         expected_payload = {
             'data': fake_entities,
@@ -711,14 +711,15 @@ class Test(unittest.TestCase):
         self.assertIsInstance(api.post_transaction(fake_id, fake_entity_set, **fake_kwargs), list)
 
         expected_uri = '/api/v2/data/fake_id/transactions?process=True'
-        for idx, call_args in enumerate(mock_make_post_request.call_args_list):
+        expected_kwargs = {'arg1': 'arg1'}
+        expected_calls = []
+        for fake_entity in fake_entities:
             expected_payload = {
-                'data': {'entities': [fake_entities[idx]]},
+                'data': {'entities': [fake_entity]},
                 'op': 'INSERT'
             }
-            fake_kwargs = {'arg1': 'arg1', 'debug': False, 'process': True}
-            self.assertEqual(call_args, mock.call(expected_payload, expected_uri, **fake_kwargs))
-            expected_uri = '/api/v2/data/fake_id/transactions?process=True'
+            expected_calls.append(mock.call(expected_payload, expected_uri, **expected_kwargs))
+        mock_make_post_request.assert_has_calls(expected_calls)
 
     @mock.patch('conduce.api.make_post_request', return_value=ResultMock())
     def test_create_resource_mime_type_json(self, mock_make_post_request):


### PR DESCRIPTION
I kept getting tripped up by this line of code, thinking it was checking for `not process`.  This cleanup also removes the superfluous kwargs from subsequent calls, which led to test cleanup.

This should result in clearer code and tests.