### PR TITLE
Check for timeout is None

### DIFF
--- a/conduce/api.py
+++ b/conduce/api.py
@@ -245,7 +245,11 @@ def wait_for_job(job_id, **kwargs):
     """
     initial_status_countdown = 9
     server_error_count = 0
-    timeout = kwargs.get('timeout', 300) * 2
+
+    timeout = kwargs.get('timeout')
+    if timeout is None:
+        timeout = 300
+    timeout *= 2
 
     while timeout > 0:
         try:


### PR DESCRIPTION
kwargs.get uses the second parameter as the default if the property is
not found on an object.  But in this case, cli.py is passing
timeout=None, so the default is not used.  instead, kwargs.get returns
None.  This results in an exception when trying to multiply None * 2.

This change drops the default parameter and does an explicit test for
timeout is None, setting to our chosen default if necessary.  Then
performs the multiply by 2 when we're sure we have a number.